### PR TITLE
Миграция към Cloudflare Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 1. Клонирайте репозитория.
 2. Настройте средата за разработка.
 3. Инсталирайте зависимостите с `npm install`.
-4. Стартирайте worker сървъра с `npm start`.
+4. Стартирайте worker сървъра локално с `wrangler dev` (може и чрез `npm start`).
 
 ## Структура на проекта
 - `src/` – изходен код (предстои създаване).
@@ -27,7 +27,8 @@
 ## Деплой с Cloudflare Wrangler
 1. Инсталирайте `wrangler` с `npm install -g wrangler` и се впишете с `wrangler login`.
 2. Попълнете идентификаторите на KV пространствата в `wrangler.toml`.
-3. Използвайте `wrangler deploy`, за да качите worker-а в Cloudflare.
+3. Тествайте локално с `wrangler dev`.
+4. Използвайте `wrangler deploy` (или `npm run deploy`) за публикуване на worker-а.
 
 ## Принос
 Моля, използвайте Pull Request при предлагане на промени.

--- a/cf-worker.js
+++ b/cf-worker.js
@@ -1,10 +1,13 @@
-export default {
-  async fetch(request, env) {
-    const { method } = request;
-    const url = new URL(request.url);
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request));
+});
+
+async function handleRequest(request) {
+  const { method } = request;
+  const url = new URL(request.url);
 
     if (url.pathname === '/orders' && method === 'GET') {
-      const data = await env.ORDERS.get('list');
+      const data = await ORDERS.get('list');
       return new Response(data || '[]', {
         headers: { 'Content-Type': 'application/json' }
       });
@@ -12,17 +15,17 @@ export default {
 
     if (url.pathname === '/orders' && method === 'POST') {
       const body = await request.json();
-      let list = await env.ORDERS.get('list', 'json');
+      let list = await ORDERS.get('list', 'json');
       if (!Array.isArray(list)) list = [];
       list.push(body);
-      await env.ORDERS.put('list', JSON.stringify(list, null, 2));
+      await ORDERS.put('list', JSON.stringify(list, null, 2));
       return new Response(JSON.stringify({ status: 'ok' }), {
         headers: { 'Content-Type': 'application/json' }
       });
     }
 
     if (url.pathname === '/page_content.json' && method === 'GET') {
-      const data = await env.PAGE_CONTENT.get('data');
+      const data = await PAGE_CONTENT.get('data');
       return new Response(data || '{}', {
         headers: { 'Content-Type': 'application/json' }
       });
@@ -30,12 +33,12 @@ export default {
 
     if (url.pathname === '/page_content.json' && method === 'POST') {
       const text = await request.text();
-      await env.PAGE_CONTENT.put('data', text);
+      await PAGE_CONTENT.put('data', text);
       return new Response(JSON.stringify({ status: 'ok' }), {
         headers: { 'Content-Type': 'application/json' }
       });
     }
 
-    return new Response('Not Found', { status: 404 });
-  }
-};
+  return new Response('Not Found', { status: 404 });
+}
+

--- a/package.json
+++ b/package.json
@@ -1,12 +1,10 @@
 {
   "name": "port-worker",
   "version": "1.0.0",
-  "main": "worker.js",
+  "main": "cf-worker.js",
   "license": "MIT",
-  "dependencies": {
-    "express": "^4.18.4"
-  },
   "scripts": {
-    "start": "node worker.js"
+    "start": "wrangler dev",
+    "deploy": "wrangler deploy"
   }
 }


### PR DESCRIPTION
## Summary
- преминаване към Cloudflare Workers API с `addEventListener`
- премахната зависимостта от Express и използване на KV storage
- добавен удобен скрипт за `wrangler dev` и `wrangler deploy`
- обновени инструкции в README

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: wrangler not found before install)*
- `wrangler --version`
- `wrangler dev cf-worker.js` *(fails: kv namespace ids missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c85042d948326b53d4ee5322efa54