### PR TITLE
Подобрение на cf-worker

### DIFF
--- a/cf-worker.js
+++ b/cf-worker.js
@@ -2,43 +2,69 @@ addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request));
 });
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
 async function handleRequest(request) {
   const { method } = request;
   const url = new URL(request.url);
 
+  if (method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
     if (url.pathname === '/orders' && method === 'GET') {
       const data = await ORDERS.get('list');
       return new Response(data || '[]', {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
 
     if (url.pathname === '/orders' && method === 'POST') {
-      const body = await request.json();
+      let body;
+      try {
+        body = await request.json();
+      } catch (e) {
+        return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
       let list = await ORDERS.get('list', 'json');
       if (!Array.isArray(list)) list = [];
       list.push(body);
       await ORDERS.put('list', JSON.stringify(list, null, 2));
       return new Response(JSON.stringify({ status: 'ok' }), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
 
     if (url.pathname === '/page_content.json' && method === 'GET') {
       const data = await PAGE_CONTENT.get('data');
       return new Response(data || '{}', {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
 
     if (url.pathname === '/page_content.json' && method === 'POST') {
+      try {
+        await request.clone().json();
+      } catch (e) {
+        return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
       const text = await request.text();
       await PAGE_CONTENT.put('data', text);
       return new Response(JSON.stringify({ status: 'ok' }), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
 
-  return new Response('Not Found', { status: 404 });
+  return new Response('Not Found', { status: 404, headers: corsHeaders });
 }
 


### PR DESCRIPTION
## Обобщение
- добавени са общи CORS заглавки
- обработване на OPTIONS заявки
- валидация на JSON при POST и връщане на 400 при грешка
- всички отговори вече включват CORS заглавките

## Тестове
- `npm install wrangler` *(успешен)*
- `npm start` *(неуспешен: липсват KV идентификатори и блокиран достъп)*


------
https://chatgpt.com/codex/tasks/task_e_686c8ba33d0c83269c28697e936e5127