### PR TITLE
Improve request routing in worker

### DIFF
--- a/cf-worker.js
+++ b/cf-worker.js
@@ -16,54 +16,68 @@ async function handleRequest(request) {
     return new Response(null, { headers: corsHeaders });
   }
 
-    if (url.pathname === '/orders' && method === 'GET') {
-      const data = await ORDERS.get('list');
-      return new Response(data || '[]', {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      });
-    }
-
-    if (url.pathname === '/orders' && method === 'POST') {
-      let body;
-      try {
-        body = await request.json();
-      } catch (e) {
-        return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
-          status: 400,
+  if (url.pathname === '/orders') {
+    switch (method) {
+      case 'GET': {
+        const data = await ORDERS.get('list');
+        return new Response(data || '[]', {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });
       }
-      let list = await ORDERS.get('list', 'json');
-      if (!Array.isArray(list)) list = [];
-      list.push(body);
-      await ORDERS.put('list', JSON.stringify(list, null, 2));
-      return new Response(JSON.stringify({ status: 'ok' }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      });
-    }
-
-    if (url.pathname === '/page_content.json' && method === 'GET') {
-      const data = await PAGE_CONTENT.get('data');
-      return new Response(data || '{}', {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      });
-    }
-
-    if (url.pathname === '/page_content.json' && method === 'POST') {
-      try {
-        await request.clone().json();
-      } catch (e) {
-        return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
-          status: 400,
+      case 'POST': {
+        let body;
+        try {
+          body = await request.json();
+        } catch (e) {
+          return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+            status: 400,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+          });
+        }
+        let list = await ORDERS.get('list', 'json');
+        if (!Array.isArray(list)) list = [];
+        list.push(body);
+        await ORDERS.put('list', JSON.stringify(list, null, 2));
+        return new Response(JSON.stringify({ status: 'ok' }), {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });
       }
-      const text = await request.text();
-      await PAGE_CONTENT.put('data', text);
-      return new Response(JSON.stringify({ status: 'ok' }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      });
+      default:
+        return new Response('Method Not Allowed', {
+          status: 405,
+          headers: corsHeaders
+        });
     }
+  } else if (url.pathname === '/page_content.json') {
+    switch (method) {
+      case 'GET': {
+        const data = await PAGE_CONTENT.get('data');
+        return new Response(data || '{}', {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
+      case 'POST': {
+        try {
+          await request.clone().json();
+        } catch (e) {
+          return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+            status: 400,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+          });
+        }
+        const text = await request.text();
+        await PAGE_CONTENT.put('data', text);
+        return new Response(JSON.stringify({ status: 'ok' }), {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
+      default:
+        return new Response('Method Not Allowed', {
+          status: 405,
+          headers: corsHeaders
+        });
+    }
+  }
 
   return new Response('Not Found', { status: 404, headers: corsHeaders });
 }


### PR DESCRIPTION
## Summary
- refactor `handleRequest` in `cf-worker.js` to use `switch` for method handling
- return 405 for unsupported methods
- keep 404 for unknown paths

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c8c65a4d483268ba2bf5bc1ade63b