### PR TITLE
Add Cloudflare types and TS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ Cloudflare Workers е безсървърна среда и се различав
    wrangler deploy
    ```
 4. След преминаване към `cf-worker.js` можете да премахнете или архивирате `worker.js`.
+5. За да няма TypeScript предупреждения, инсталирайте типовете и добавете конфигурация:
+   ```bash
+   npm install --save-dev @cloudflare/workers-types
+   ```
+   Създайте `tsconfig.json` със съдържание
+   ```json
+   {
+     "compilerOptions": { "types": ["@cloudflare/workers-types"] }
+   }
+   ```
+   и файл `globals.d.ts`:
+   ```ts
+   /// <reference types="@cloudflare/workers-types" />
+   declare const ORDERS: KVNamespace;
+   declare const PAGE_CONTENT: KVNamespace;
+   ```
 
 ## Стари демо страници
 В папка `src/` ще намерите по-ранни примери за клиентска и администраторска страница със смяна на тема и локално задаване на цена. Могат да се използват за справка или да бъдат премахнати при нужда.

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="@cloudflare/workers-types" />
+
+declare const ORDERS: KVNamespace;
+declare const PAGE_CONTENT: KVNamespace;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "port-worker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "port-worker",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250708.0"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250708.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250708.0.tgz",
+      "integrity": "sha512-jEIHy5lPtGFumnRWNR4tE9lZvR+E+DRGvSKe/C32uAlk9n7fjGfyCGN1QSCn7MTEZjXLWTck3K0fsmOjt6VWCQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "start": "wrangler dev",
     "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250708.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  }
+}


### PR DESCRIPTION
## Summary
- configure TypeScript for Cloudflare Workers
- declare ORDERS and PAGE_CONTENT globals
- document installation of worker types in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686da443474883268cac5c74a8b3c12a