### PR TITLE
Add Cloudflare Workers types

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ npm start
 ## Cloudflare Workers
 Cloudflare Workers е безсървърна среда и се различава от Node изпълнението на `worker.js`.
 Вместо Express и локална файлова система се използват `fetch` събития и KV хранилища.
+За коректни типови проверки инсталирайте dev-зависимостта `@cloudflare/workers-types`:
+```bash
+npm install --save-dev @cloudflare/workers-types
+```
 
 ### Деплой на `cf-worker.js`
 1. Инсталирайте `wrangler` и създайте KV пространства за `ORDERS` и `PAGE_CONTENT`.

--- a/cf-worker.js
+++ b/cf-worker.js
@@ -1,7 +1,7 @@
 /// <reference types="@cloudflare/workers-types" />
 /* global ORDERS, PAGE_CONTENT */
 
-addEventListener('fetch', event => {
+addEventListener('fetch', /** @param {FetchEvent} event */ (event) => {
   event.respondWith(handleRequest(event.request));
 });
 
@@ -37,6 +37,7 @@ async function handleRequest(request) {
             headers: { ...corsHeaders, 'Content-Type': 'application/json' }
           });
         }
+        /** @type {any[]} */
         let list = await ORDERS.get('list', 'json');
         if (!Array.isArray(list)) list = [];
         list.push(body);

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,2 @@
+declare const ORDERS: KVNamespace;
+declare const PAGE_CONTENT: KVNamespace;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "port-worker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "port-worker",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250708.0"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250708.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250708.0.tgz",
+      "integrity": "sha512-jEIHy5lPtGFumnRWNR4tE9lZvR+E+DRGvSKe/C32uAlk9n7fjGfyCGN1QSCn7MTEZjXLWTck3K0fsmOjt6VWCQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "start": "wrangler dev",
     "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240527.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "lib": [
+      "es2020",
+      "webworker"
+    ],
+    "types": [
+      "@cloudflare/workers-types"
+    ],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "cf-worker.js",
+    "globals.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- install `@cloudflare/workers-types` as a dev dependency
- configure TypeScript for JS checking
- declare global KV namespaces
- update worker code with type hints
- mention needed dev dependency in README

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_686da67140008326b351e8c665776cd7