### PR TITLE
Прехвърляне на Cloudflare worker и локална версия

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
    ```bash
    npm install
    ```
-2. Стартирайте `worker.js`:
+2. Стартирайте `local-worker.js`:
    ```bash
-   node worker.js
+   node local-worker.js
    ```
    Сървърът слуша на порт **3000** и обслужва маршрути `/orders` и `/page_content.json`.
 
@@ -32,7 +32,7 @@ npm start
 - **orders.json** пази направените поръчки при локално стартиране.
 
 ## Cloudflare Workers
-Cloudflare Workers е безсървърна среда и се различава от Node изпълнението на `worker.js`.
+Cloudflare Workers е безсървърна среда и се различава от Node изпълнението на `local-worker.js`.
 Вместо Express и локална файлова система се използват `fetch` събития и KV хранилища.
 За коректни типови проверки инсталирайте dev-зависимостта `@cloudflare/workers-types`:
 ```bash
@@ -61,14 +61,14 @@ npm install --save-dev @cloudflare/workers-types
    Без локалните `globals.d.ts` и пакета `@cloudflare/workers-types` Dashboard често
    отчита типови грешки.
 
-### Деплой на `cf-worker.js`
+### Деплой на `worker.js`
 1. Инсталирайте `wrangler`.
 2. Попълнете идентификаторите в `wrangler.toml`.
 3. Публикувайте с:
    ```bash
    wrangler deploy
    ```
-4. След преминаване към `cf-worker.js` можете да премахнете или архивирате `worker.js`.
+4. След преминаване към `worker.js` можете да премахнете или архивирате `local-worker.js`.
 
 ## Стари демо страници
 В папка `src/` ще намерите по-ранни примери за клиентска и администраторска страница със смяна на тема и локално задаване на цена. Могат да се използват за справка или да бъдат премахнати при нужда.

--- a/local-worker.js
+++ b/local-worker.js
@@ -1,9 +1,8 @@
-/// <reference types="@cloudflare/workers-types" />
-/* global ORDERS, PAGE_CONTENT */
+const express = require('express');
+const fs = require('fs/promises');
 
-addEventListener('fetch', /** @param {FetchEvent} event */ (event) => {
-  event.respondWith(handleRequest(event.request));
-});
+const app = express();
+app.use(express.json());
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -11,7 +10,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type'
 };
 
-async function handleRequest(request) {
+async function handleRequest(request, env) {
   const { method } = request;
   const url = new URL(request.url);
 
@@ -22,7 +21,7 @@ async function handleRequest(request) {
   if (url.pathname === '/orders') {
     switch (method) {
       case 'GET': {
-        const data = await ORDERS.get('list');
+        const data = await env.ORDERS.get('list');
         return new Response(data || '[]', {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });
@@ -31,17 +30,16 @@ async function handleRequest(request) {
         let body;
         try {
           body = await request.json();
-        } catch (e) {
+        } catch {
           return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
             status: 400,
             headers: { ...corsHeaders, 'Content-Type': 'application/json' }
           });
         }
-        /** @type {any[]} */
-        let list = await ORDERS.get('list', 'json');
+        let list = await env.ORDERS.get('list', 'json');
         if (!Array.isArray(list)) list = [];
         list.push(body);
-        await ORDERS.put('list', JSON.stringify(list, null, 2));
+        await env.ORDERS.put('list', JSON.stringify(list, null, 2));
         return new Response(JSON.stringify({ status: 'ok' }), {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });
@@ -55,7 +53,7 @@ async function handleRequest(request) {
   } else if (url.pathname === '/page_content.json') {
     switch (method) {
       case 'GET': {
-        const data = await PAGE_CONTENT.get('data');
+        const data = await env.PAGE_CONTENT.get('data');
         return new Response(data || '{}', {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });
@@ -63,14 +61,14 @@ async function handleRequest(request) {
       case 'POST': {
         try {
           await request.clone().json();
-        } catch (e) {
+        } catch {
           return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
             status: 400,
             headers: { ...corsHeaders, 'Content-Type': 'application/json' }
           });
         }
         const text = await request.text();
-        await PAGE_CONTENT.put('data', text);
+        await env.PAGE_CONTENT.put('data', text);
         return new Response(JSON.stringify({ status: 'ok' }), {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });
@@ -86,3 +84,45 @@ async function handleRequest(request) {
   return new Response('Not Found', { status: 404, headers: corsHeaders });
 }
 
+const env = {
+  ORDERS: {
+    async get(key, type) {
+      try {
+        const text = await fs.readFile('./orders.json', 'utf8');
+        return type === 'json' ? JSON.parse(text) : text;
+      } catch {
+        return type === 'json' ? null : null;
+      }
+    },
+    async put(key, value) {
+      await fs.writeFile('./orders.json', value);
+    }
+  },
+  PAGE_CONTENT: {
+    async get(key) {
+      try {
+        return await fs.readFile('./page_content.json', 'utf8');
+      } catch {
+        return null;
+      }
+    },
+    async put(key, value) {
+      await fs.writeFile('./page_content.json', value);
+    }
+  }
+};
+
+app.all('*', async (req, res) => {
+  const request = new Request(`http://localhost:3000${req.originalUrl}`, {
+    method: req.method,
+    headers: req.headers,
+    body: ['GET', 'HEAD', 'OPTIONS'].includes(req.method) ? undefined : JSON.stringify(req.body)
+  });
+  const response = await handleRequest(request, env);
+  const text = await response.text();
+  res.status(response.status);
+  response.headers.forEach((v, k) => res.setHeader(k, v));
+  res.send(text);
+});
+
+app.listen(3000, () => console.log('Local worker listening on port 3000'));

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "port-worker",
   "version": "1.0.0",
-  "main": "cf-worker.js",
+  "main": "worker.js",
   "license": "MIT",
   "scripts": {
     "start": "wrangler dev",
+    "local": "node local-worker.js",
     "deploy": "wrangler deploy"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "skipLibCheck": true
   },
   "include": [
-    "cf-worker.js",
+    "worker.js",
     "globals.d.ts"
   ]
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "port-worker"
-main = "cf-worker.js"
+main = "worker.js"
 compatibility_date = "2024-04-05"
 
 # KV пространствата съхраняват поръчките и съдържанието на сайта.


### PR DESCRIPTION
## Обобщение
- преименуван е `cf-worker.js` на `worker.js` и е премахнат Express вариантът
- добавен е нов `local-worker.js` за локални тестове с файлово четене/писане
- конфигуриран е Cloudflare module синтаксис и достъп до KV чрез `env`
- обновени са `package.json`, `tsconfig.json` и `wrangler.toml`
- README е коригиран с новите имена и инструкции

## Тестване
- `npm test` *(очаквано липсва скрипт)*
- `npm run lint` *(очаквано липсва скрипт)*

------
https://chatgpt.com/codex/tasks/task_e_686dae8d87cc83268e6182e412728858