### PR TITLE
Add API_BASE constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ wrangler dev
 npm start
 ```
 
+## Настройване на `API_BASE`
+В `admin.html` в началото на JavaScript кода има константа `API_BASE`.
+При локално стартиране стойността може да остане празен низ:
+
+```html
+const API_BASE = '';
+```
+
+При деплой на Cloudflare Worker заменете стойността с URL адреса на вашия Worker,
+например:
+
+```html
+const API_BASE = 'https://myshop.worker.dev';
+```
+
+
 ## Страници
 - **index.html** – основната витрина. Данните за продукти и навигация се взимат от ключа `page_content` в KV чрез `/page_content.json`.
 - **checkout.html** – страница за завършване на поръчката. Изпраща кошницата към `/orders`.

--- a/admin.html
+++ b/admin.html
@@ -134,6 +134,7 @@
     </div>
     
     <script>
+    const API_BASE = '';
     document.addEventListener('DOMContentLoaded', () => {
         let appData = {};
         let ordersData = [];
@@ -159,7 +160,7 @@
         // --- INITIALIZATION ---
         async function init() {
             try {
-                const response = await fetch(`page_content.json?v=${Date.now()}`);
+                const response = await fetch(`${API_BASE}/page_content.json?v=${Date.now()}`);
                 if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
                 appData = await response.json();
                 renderAll();
@@ -728,7 +729,7 @@
         async function saveChanges(btn) {
             const jsonString = JSON.stringify(appData, null, 2);
             try {
-                const response = await fetch('page_content.json', {
+                const response = await fetch(`${API_BASE}/page_content.json`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: jsonString


### PR DESCRIPTION
## Summary
- configure API_BASE constant in admin dashboard
- use API_BASE for fetch requests
- document API_BASE usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686de50852448326a7f5bf91fcf07a63