### PR TITLE
Fix padding for quest header

### DIFF
--- a/quest.html
+++ b/quest.html
@@ -72,6 +72,7 @@
       .main-container {
         width: 100%;
         max-width: 700px;
+        padding-top: var(--header-height);
       }
       .questionnaire-container,
       .loading-container,
@@ -625,7 +626,7 @@
       </svg>
     </button>
 
-    <div class="main-container">
+    <main class="main-container">
       <a
         href="index.html"
         class="btn-primary"
@@ -1049,7 +1050,7 @@
           Започни отначало
         </button>
       </div>
-    </div>
+    </main>
 
     <script>
       document.addEventListener("DOMContentLoaded", async function () {


### PR DESCRIPTION
## Summary
- wrap questionnaire in `<main>` container
- give the container top padding so the header doesn't overlap

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871de5cd35083269d9986db806e93d5