### PR TITLE
Fix questionnaire main container padding

### DIFF
--- a/quest.html
+++ b/quest.html
@@ -44,7 +44,7 @@
     </header>
 
 
-    <div class="main-container">
+    <main class="main-container">
       <a
         href="index.html"
         class="btn-primary"
@@ -468,7 +468,7 @@
           Започни отначало
         </button>
       </div>
-    </div>
+</main>
 
     <script src="questionnaire.js"></script>
     <footer class="main-footer" style="padding: 2rem 0; text-align: center">

--- a/questionnaire.css
+++ b/questionnaire.css
@@ -57,6 +57,7 @@
       .main-container {
         width: 100%;
         max-width: 700px;
+        padding-top: var(--header-height);
       }
       .questionnaire-container,
       .loading-container,


### PR DESCRIPTION
## Summary
- wrap questionnaire content in `<main class="main-container">` instead of a div
- ensure questionnaire content is pushed below the header by adding `padding-top`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6871e385e1b48326957f6ed7fc078c55