### PR TITLE
Add quest modal support

### DIFF
--- a/index.css
+++ b/index.css
@@ -385,6 +385,27 @@ main { padding-top: var(--header-height); }
 #back-to-top:hover { border-color: var(--accent); transform: scale(1.1); }
 #back-to-top.visible { opacity: 1; visibility: visible; transform: translateY(0); }
 
+/* --- QUEST MODAL --- */
+#quest-modal-backdrop {
+    position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+    background: rgba(0,0,0,0.6); z-index: 1000;
+    display: none; opacity: 0; transition: opacity 0.3s ease;
+}
+#quest-modal-container {
+    position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+    background: var(--bg-secondary); z-index: 1001;
+    display: none; flex-direction: column; opacity: 0;
+    transform: translateY(20px); transition: opacity 0.3s ease, transform 0.3s ease;
+}
+#quest-modal-backdrop.show, #quest-modal-container.show { display: flex; opacity: 1; }
+#quest-modal-container.show { transform: translateY(0); }
+#quest-modal-container iframe { border: none; width: 100%; height: 100%; flex-grow: 1; }
+#close-quest-modal-btn {
+    align-self: flex-end; font-size: 2rem; background: none; border: none;
+    cursor: pointer; color: var(--text-secondary); padding: 1rem;
+}
+body.modal-open { overflow: hidden; }
+
 #theme-toggle {
     background: none; border: none; cursor: pointer; display: flex; align-items: center; gap: 0.5rem;
     color: var(--text-secondary); font-weight: 500; font-family: 'Plus Jakarta Sans', sans-serif;

--- a/index.html
+++ b/index.html
@@ -130,6 +130,12 @@
 
     <a href="#" id="back-to-top" aria-label="Back to top">↑</a>
 
+    <div id="quest-modal-backdrop" class="modal-backdrop"></div>
+    <div id="quest-modal-container" class="modal-container">
+        <button id="close-quest-modal-btn" class="close-modal-btn" aria-label="Затвори">×</button>
+        <iframe id="quest-modal-iframe" src="" loading="lazy" title="BIOCODE въпросник"></iframe>
+    </div>
+
     <script src="index.js" type="module"></script>
     
 </body>

--- a/index.js
+++ b/index.js
@@ -22,7 +22,13 @@ const DOM = {
     menuToggle: document.querySelector('.menu-toggle'),
     navLinksContainer: document.querySelector('.nav-links'),
     navOverlay: document.querySelector('.nav-overlay'),
-    body: document.body
+    body: document.body,
+    questModal: {
+        backdrop: document.getElementById('quest-modal-backdrop'),
+        container: document.getElementById('quest-modal-container'),
+        iframe: document.getElementById('quest-modal-iframe'),
+        closeBtn: document.getElementById('close-quest-modal-btn')
+    }
 };
 
 function debounce(func, wait) {
@@ -351,6 +357,29 @@ function initializeGlobalScripts() {
             if (!e.target.closest('#theme-toggle')) {
                 closeMenu();
             }
+        }
+    });
+
+    // --- Quest Modal ---
+    function openQuestModal(url) {
+        DOM.questModal.iframe.src = url || 'quest.html';
+        DOM.questModal.container.classList.add('show');
+        DOM.questModal.backdrop.classList.add('show');
+        DOM.body.classList.add('modal-open');
+    }
+    function closeQuestModal() {
+        DOM.questModal.container.classList.remove('show');
+        DOM.questModal.backdrop.classList.remove('show');
+        DOM.questModal.iframe.src = '';
+        DOM.body.classList.remove('modal-open');
+    }
+    DOM.questModal.closeBtn.addEventListener('click', closeQuestModal);
+    DOM.questModal.backdrop.addEventListener('click', closeQuestModal);
+    document.addEventListener('click', e => {
+        const questLink = e.target.closest('a[href$="quest.html"]');
+        if (questLink) {
+            e.preventDefault();
+            openQuestModal(questLink.getAttribute('href'));
         }
     });
 

--- a/quest.html
+++ b/quest.html
@@ -469,19 +469,6 @@
       </div>
 </main>
 
-    <footer class="main-footer">
-      <div class="container">
-        <div class="footer-grid" id="footer-grid-container">
-          <!-- Футър колоните ще бъдат генерирани от JS -->
-        </div>
-        <div class="footer-bottom" id="footer-copyright-container">
-          <!-- Copyright текстът ще бъде генериран от JS -->
-        </div>
-      </div>
-    </footer>
-
-    <a href="#" id="back-to-top" aria-label="Back to top">↑</a>
-
     <script src="questionnaire.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove redundant footer and back-to-top elements from `quest.html`
- add modal container markup to `index.html`
- style quest modal via `index.css`
- load questionnaire in a modal overlay from `index.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68724dcd10d483269b7f361d937c78e9