### PR TITLE
Remove quest header and link questionnaire in menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,8 +202,9 @@ function renderHeader(settings, navigation) {
     DOM.header.brandSlogan.textContent = settings.site_slogan;
 
     const navItemsHTML = navigation.map(item => `<li><a href="${item.link}">${item.text}</a></li>`).join('');
+    const questionnaireLink = '<li><a href="quest.html">Въпросник</a></li>';
     const persistentLis = DOM.header.navLinks.querySelectorAll('li:nth-last-child(-n+2)');
-    DOM.header.navLinks.innerHTML = navItemsHTML;
+    DOM.header.navLinks.innerHTML = navItemsHTML + questionnaireLink;
     persistentLis.forEach(li => DOM.header.navLinks.appendChild(li));
 
     updateCartCount();

--- a/quest.html
+++ b/quest.html
@@ -15,37 +15,6 @@
     <link rel="stylesheet" href="questionnaire.css" />
   </head>
   <body>
-    <header class="main-header">
-      <div class="header-container">
-        <a href="index.html" class="logo-container" id="header-logo-link">
-          <img src="" alt="BIOCODE Logo" id="header-logo-img" />
-          <div>
-            <span class="brand-name" id="header-brand-name">BIOCODE</span>
-            <span class="brand-slogan" id="header-brand-slogan"></span>
-          </div>
-        </a>
-        <nav class="main-nav">
-          <ul class="nav-links" id="main-nav-links">
-            <li>
-              <a href="checkout.html" class="cart-link">Количка (<span id="cart-count">0</span>)</a>
-            </li>
-            <li>
-              <button id="theme-toggle" aria-label="Смяна на светла/тъмна тема">
-                <span id="theme-icon-sun" class="theme-icon">🌞</span>
-                <span id="theme-icon-moon" class="theme-icon">🌙</span>
-                <span class="theme-toggle-text">Тема</span>
-              </button>
-            </li>
-          </ul>
-        </nav>
-        <button class="menu-toggle" aria-label="Toggle Menu">
-          <span></span>
-          <span></span>
-          <span></span>
-        </button>
-      </div>
-    </header>
-    <div class="nav-overlay"></div>
 
 
     <main class="main-container">

--- a/questionnaire.css
+++ b/questionnaire.css
@@ -57,7 +57,7 @@
       .main-container {
         width: 100%;
         max-width: 700px;
-        padding-top: var(--header-height);
+          padding-top: 0;
       }
       .questionnaire-container,
       .loading-container,


### PR DESCRIPTION
## Summary
- strip header and overlay from `quest.html`
- adjust questionnaire styles for missing header
- show questionnaire link in main navigation

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687250ddea208326bf220ff9f78d90c8