### PR TITLE
Compact quest navigation

### DIFF
--- a/quest.html
+++ b/quest.html
@@ -383,7 +383,6 @@
           </div>
           <div class="navigation-buttons">
             <button type="button" class="nav-btn" id="back-btn">Назад</button>
-            <a href="index.html" class="nav-btn" id="menu-btn">Назад към менюто</a>
             <button type="button" class="nav-btn" id="next-btn">Напред</button>
           </div>
         </form>

--- a/questionnaire.css
+++ b/questionnaire.css
@@ -246,13 +246,13 @@
       .navigation-buttons {
         display: flex;
         justify-content: center;
-        gap: 1rem;
-        margin-top: 2.5rem;
+        gap: 0.5rem;
+        margin-top: 1rem;
       }
       .nav-btn {
-        padding: 0.75rem 1.5rem;
+        padding: 0.5rem 1rem;
         border: none;
-        border-radius: 8px;
+        border-radius: 6px;
         font-family: "Plus Jakarta Sans", sans-serif;
         font-size: 1rem;
         font-weight: 600;
@@ -268,17 +268,6 @@
         background-color: var(--bg-primary);
         border-color: var(--accent);
         color: var(--accent);
-      }
-      .nav-btn#menu-btn {
-        background-color: var(--accent);
-        color: var(--bg-primary);
-      }
-      [data-theme="dark"] .nav-btn#menu-btn {
-        color: #000;
-      }
-      .nav-btn#menu-btn:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 4px 15px -5px var(--accent);
       }
       .nav-btn#next-btn {
         background-color: var(--accent);

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -103,7 +103,7 @@
             step.classList.toggle("active", index === currentStepIndex),
           );
           progressBar.style.width = `${(currentStepIndex / (totalSteps - 1)) * 100}%`;
-          backBtn.style.display = currentStepIndex === 0 ? "none" : "block";
+          backBtn.style.display = "block";
           nextBtn.textContent =
             currentStepIndex === totalSteps - 1
               ? "Генерирай Протокол"
@@ -297,6 +297,15 @@
             currentStepIndex--;
             updateForm();
             window.scrollTo(0, 0);
+          } else {
+            if (
+              window.parent &&
+              typeof window.parent.closeQuestModal === "function"
+            ) {
+              window.parent.closeQuestModal();
+            } else {
+              window.location.href = "index.html";
+            }
           }
         });
 


### PR DESCRIPTION
## Summary
- slim down questionnaire navigation
- keep only Back and Next buttons
- always show Back and close modal on first step
- update styling for smaller navigation buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68725449570c83269790394e8d0c7352