### PR TITLE
Поправен път към логото

### DIFF
--- a/kv/page_content.json
+++ b/kv/page_content.json
@@ -2,7 +2,7 @@
   "settings": {
     "site_name": "BIOCODE",
     "site_slogan": "the science of life",
-    "logo_url": "https://raw.githubusercontent.com/Radilovk/face/refs/heads/main/assets/ChatGPT%20Image%20Jul%206%2C%202025%2C%2010_50_47%20PM.png"
+    "logo_url": "https://radilovk.github.io/face/assets/ChatGPT%20Image%20Jul%206,%202025,%2010_50_47%20PM.png"
   },
   "navigation": [
     {


### PR DESCRIPTION
## Summary
- коригиран е URL адресът на логото в `page_content.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873d65cde0883269f7a1880ff031867