### PR TITLE
Добавен toast компонент за клиентската част

### DIFF
--- a/index.css
+++ b/index.css
@@ -416,6 +416,24 @@ body.modal-open { overflow: hidden; }
 [data-theme="dark"] #theme-icon-sun { display: none; }
 [data-theme="light"] #theme-icon-moon { display: none; }
 
+/* --- Toast Notifications --- */
+#toast-container {
+    position: fixed; top: 10px; left: 10px; right: 10px;
+    z-index: 2000; display: flex; flex-direction: column; gap: 0.5rem;
+    pointer-events: none;
+}
+.toast {
+    padding: 0.75rem 1rem; border-radius: 6px; color: #fff;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.15); pointer-events: auto;
+    animation: toast-slide-in 0.4s ease-out;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.toast.success { background-color: var(--success-color); }
+.toast.error { background-color: #dc3545; }
+.toast.info { background-color: var(--accent); }
+.toast.fade-out { opacity: 0; transform: translateY(-20px); }
+@keyframes toast-slide-in { from { transform: translateY(-100%); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+
 /* --- UTILITY & ANIMATIONS --- */
 .fade-in-up {
     opacity: 0; transform: translateY(30px);

--- a/index.html
+++ b/index.html
@@ -141,6 +141,8 @@
         <iframe id="quest-modal-iframe" src="" loading="lazy" title="BIOCODE въпросник"></iframe>
     </div>
 
+    <div id="toast-container"></div>
+
     <script src="index.js" type="module"></script>
     
 </body>

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ const DOM = {
         backdrop: document.getElementById('quest-modal-backdrop'),
         container: document.getElementById('quest-modal-container'),
         iframe: document.getElementById('quest-modal-iframe')
-    }
+    },
+    toastContainer: document.getElementById('toast-container')
 };
 
 function debounce(func, wait) {
@@ -162,6 +163,18 @@ const updateCartCount = () => {
     DOM.header.cartCount.textContent = count;
 };
 
+const showToast = (message, type = 'info', duration = 3000) => {
+    if (!DOM.toastContainer) return;
+    const toast = document.createElement('div');
+    toast.className = `toast ${type}`;
+    toast.textContent = message;
+    DOM.toastContainer.appendChild(toast);
+    setTimeout(() => {
+        toast.classList.add('fade-out');
+        toast.addEventListener('transitionend', () => toast.remove());
+    }, duration);
+};
+
 const showAddToCartFeedback = (productId) => {
     const card = document.querySelector(`.product-card[data-product-id="${productId}"]`);
     if (!card) return;
@@ -183,13 +196,13 @@ const addToCart = (id, name, price, inventory) => {
     const idx = cart.findIndex(i => i.id === id);
     if (idx > -1) {
         if (maxQty && cart[idx].quantity >= maxQty) {
-            alert('Няма достатъчна наличност.');
+            showToast('Няма достатъчна наличност.', 'error');
             return;
         }
         cart[idx].quantity++;
     } else {
         if (maxQty === 0) {
-            alert('Продуктът е изчерпан.');
+            showToast('Продуктът е изчерпан.', 'error');
             return;
         }
         cart.push({ id, name, price: Number(price), quantity: 1, inventory: maxQty });


### PR DESCRIPTION
## Резюме
- добавен контейнер за toast известия в `index.html`
- имплементирана нова функция `showToast` и използване вместо `alert`
- стилове за `.toast` под секцията „Помощни елементи“ в `index.css`

## Тестове
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d93ecc4608326b5ae9dc79ad8a4ac