### PR TITLE
Set site to dark theme only

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -17,13 +17,9 @@
     <style>
         :root {
             --bg-primary-dark: #0D0F12; --bg-secondary-dark: #12151A; --text-primary-dark: #E9ECEF; --text-secondary-dark: #A0AEC0; --accent-dark: #00E0E0; --border-color-dark: rgba(255, 255, 255, 0.1); --error-color-dark: #ff5c5c;
-            --bg-primary-light: #F8F9FA; --bg-secondary-light: #FFFFFF; --text-primary-light: #121212; --text-secondary-light: #555555; --accent-light: #006A6A; --border-color-light: #E0E0E0; --error-color-light: #d93025;
         }
         [data-theme="dark"] {
             --bg-primary: var(--bg-primary-dark); --bg-secondary: var(--bg-secondary-dark); --text-primary: var(--text-primary-dark); --text-secondary: var(--text-secondary-dark); --accent: var(--accent-dark); --border-color: var(--border-color-dark); --error-color: var(--error-color-dark);
-        }
-        [data-theme="light"] {
-            --bg-primary: var(--bg-primary-light); --bg-secondary: var(--bg-secondary-light); --text-primary: var(--text-primary-light); --text-secondary: var(--text-secondary-light); --accent: var(--accent-light); --border-color: var(--border-color-light); --error-color: var(--error-color-light);
         }
         * { margin: 0; padding: 0; box-sizing: border-box; }
         html { scroll-behavior: smooth; }
@@ -100,13 +96,6 @@
                 <ul class="nav-links" id="main-nav-links">
                     <li><a href="index.html">Начало</a></li>
                     <li><a href="checkout.html" class="cart-link">Количка (<span id="cart-count">0</span>)</a></li>
-                    <li>
-                        <button id="theme-toggle" aria-label="Смяна на светла/тъмна тема">
-                            <span id="theme-icon-sun" class="theme-icon">🌞</span>
-                            <span id="theme-icon-moon" class="theme-icon">🌙</span>
-                            <span class="theme-toggle-text">Тема</span>
-                        </button>
-                    </li>
                 </ul>
             </nav>
             <button class="menu-toggle" aria-label="Toggle Menu">
@@ -274,7 +263,6 @@
         const applyPromoBtn = document.getElementById('apply-promo');
         const discountRow = document.getElementById('discount-row');
         const discountEl = document.getElementById('summary-discount');
-        const themeToggle = document.getElementById('theme-toggle');
         const menuToggle = document.querySelector('.menu-toggle');
         const navLinks = document.querySelector('.nav-links');
         const navOverlay = document.querySelector('.nav-overlay');
@@ -482,13 +470,6 @@
         renderProducts();
         updateCartCount();
 
-        if (themeToggle) {
-            themeToggle.addEventListener('click', () => {
-                const newTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-                document.documentElement.setAttribute('data-theme', newTheme);
-                localStorage.setItem('theme', newTheme);
-            });
-        }
 
         if (menuToggle) {
             const toggleMenu = () => {

--- a/index.css
+++ b/index.css
@@ -3,22 +3,6 @@
 /* ======================================================= */
 
 :root {
-    /* Light Theme Variables */
-    --bg-primary-light: #FFFFFF;
-    --bg-secondary-light: #FDFDFD;
-    --text-primary-light: #121212;
-    --text-secondary-light: #444444;
-    --accent-light: #007B7B;
-    --accent-rgb-light: 0, 123, 123;
-    --border-color-light: #D1D5DB;
-    --shadow-light: rgba(0, 123, 123, 0.12);
-    --spotlight-color-light: rgba(0, 123, 123, 0.08);
-    --note-color-light: #006666;
-    --success-color-light: #28a745;
-    --skeleton-bg-light: #e0e0e0;
-    --skeleton-highlight-light: #f5f5f5;
-
-
     /* Dark Theme Variables */
     --bg-primary-dark: #0D0F12;
     --bg-secondary-dark: #12151A;
@@ -34,30 +18,11 @@
     --skeleton-bg-dark: #1a1e25;
     --skeleton-highlight-dark: #2a303a;
 
-    --header-bg-light: rgba(255, 255, 255, 0.8);
     --header-bg-dark: rgba(13, 15, 18, 0.8);
     --header-height: 70px;
-    --overlay-bg-light: rgba(0,0,0,0.3);
     --overlay-bg-dark: rgba(0,0,0,0.5);
 }
 
-[data-theme="light"] {
-    --bg-primary: var(--bg-primary-light);
-    --bg-secondary: var(--bg-secondary-light);
-    --text-primary: var(--text-primary-light);
-    --text-secondary: var(--text-secondary-light);
-    --accent: var(--accent-light);
-    --accent-rgb: var(--accent-rgb-light);
-    --border-color: var(--border-color-light);
-    --shadow-color: var(--shadow-light);
-    --spotlight-color: var(--spotlight-color-light);
-    --note-color: var(--note-color-light);
-    --success-color: var(--success-color-light);
-    --skeleton-bg: var(--skeleton-bg-light);
-    --skeleton-highlight: var(--skeleton-highlight-light);
-    --header-bg: var(--header-bg-light);
-    --overlay-bg: var(--overlay-bg-light);
-}
 
 [data-theme="dark"] {
     --bg-primary: var(--bg-primary-dark);
@@ -168,7 +133,6 @@ body.nav-open {
 .logo-container img { height: 40px; width: 40px; }
 .logo-container .brand-name { font-size: 1.2rem; font-weight: 600; color: var(--text-primary); white-space: nowrap; }
 .logo-container .brand-slogan { font-size: 0.75rem; color: var(--text-secondary); display: block; line-height: 1; }
-[data-theme="light"] .logo-container .brand-slogan { color: #495057; }
 
 .main-nav { display: flex; align-items: center; gap: 1.5rem; }
 .nav-links { list-style: none; display: flex; gap: 1.5rem; align-items: center; }
@@ -413,16 +377,6 @@ main { padding-top: var(--header-height); }
 #quest-modal-container iframe { border: none; width: 100%; height: 100%; flex-grow: 1; }
 body.modal-open { overflow: hidden; }
 
-#theme-toggle {
-    background: none; border: none; cursor: pointer; display: flex; align-items: center; gap: 0.5rem;
-    color: var(--text-secondary); font-weight: 500; font-family: 'Plus Jakarta Sans', sans-serif;
-    font-size: inherit; padding: 0.5rem; border-radius: 8px; transition: color 0.3s ease, background-color 0.3s ease;
-}
-#theme-toggle:hover { color: var(--accent); background-color: rgba(var(--accent-rgb), 0.1); }
-#theme-toggle .theme-icon { font-size: 20px; line-height: 1; }
-.theme-toggle-text { font-size: 1rem; }
-[data-theme="dark"] #theme-icon-sun { display: none; }
-[data-theme="light"] #theme-icon-moon { display: none; }
 
 /* --- Toast Notifications --- */
 #toast-container {
@@ -462,16 +416,14 @@ body.modal-open { overflow: hidden; }
     }
     .nav-links.active { right: 0; }
     .nav-links li { text-align: center; }
-    .nav-links a, #theme-toggle { font-size: 1.2rem; }
+    .nav-links a { font-size: 1.2rem; }
     .menu-toggle { display: flex; }
-    .theme-toggle-text { display: inline; } /* Покажи текста в мобилното меню */
 }
 
 @media (max-width: 768px) {
     .info-card-section .container, .info-card-section.image-align-right .container {
         flex-direction: column; text-align: center; gap: 2rem;
     }
-    .theme-toggle-text { display: none; } /* Скрий текста до иконата на десктоп */
 }
 
 @media (min-width: 768px) { .product-grid { grid-template-columns: repeat(2, 1fr); } }

--- a/index.html
+++ b/index.html
@@ -41,13 +41,6 @@
                     <li>
                         <a href="checkout.html" class="cart-link">Количка (<span id="cart-count">0</span>)</a>
                     </li>
-                    <li>
-                        <button id="theme-toggle" aria-label="Смяна на светла/тъмна тема">
-                            <span id="theme-icon-sun" class="theme-icon">🌞</span>
-                            <span id="theme-icon-moon" class="theme-icon">🌙</span>
-                            <span class="theme-toggle-text">Тема</span>
-                        </button>
-                    </li>
                 </ul>
             </nav>
             <button class="menu-toggle" aria-label="Toggle Menu">

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const DOM = {
         gridContainer: document.getElementById('footer-grid-container'),
         copyrightContainer: document.getElementById('footer-copyright-container')
     },
-    themeToggle: document.getElementById('theme-toggle'),
     backToTopBtn: document.getElementById('back-to-top'),
     menuToggle: document.querySelector('.menu-toggle'),
     navLinksContainer: document.querySelector('.nav-links'),
@@ -354,15 +353,6 @@ function initializePageInteractions() {
 }
 
 function initializeGlobalScripts() {
-    DOM.themeToggle.addEventListener('click', () => {
-        const newTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', newTheme);
-        localStorage.setItem('theme', newTheme);
-        // Re-initialize canvas particles on theme change to adopt new colors
-        if (document.getElementById('neuron-canvas')) {
-            initializeCanvasAnimation(true); // Pass true to force re-initialization
-        }
-    });
 
     window.addEventListener('scroll', () => {
         DOM.backToTopBtn.classList.toggle('visible', window.scrollY > 300);
@@ -383,9 +373,7 @@ function initializeGlobalScripts() {
     DOM.navOverlay.addEventListener('click', closeMenu);
     DOM.navLinksContainer.addEventListener('click', e => {
         if (e.target.tagName === 'A' || e.target.closest('button')) {
-            if (!e.target.closest('#theme-toggle')) {
-                closeMenu();
-            }
+            closeMenu();
         }
     });
 

--- a/questionnaire.css
+++ b/questionnaire.css
@@ -1,11 +1,4 @@
       :root {
-        --bg-primary-light: #f8f9fa;
-        --bg-secondary-light: #ffffff;
-        --text-primary-light: #121212;
-        --text-secondary-light: #555555;
-        --accent-light: #006a6a;
-        --border-color-light: #e0e0e0;
-        --error-color-light: #d32f2f;
         --bg-primary-dark: #0d0f12;
         --bg-secondary-dark: #12151a;
         --text-primary-dark: #e9ecef;
@@ -13,15 +6,6 @@
         --accent-dark: #00e0e0;
         --border-color-dark: rgba(255, 255, 255, 0.1);
         --error-color-dark: #e57373;
-      }
-      [data-theme="light"] {
-        --bg-primary: var(--bg-primary-light);
-        --bg-secondary: var(--bg-secondary-light);
-        --text-primary: var(--text-primary-light);
-        --text-secondary: var(--text-secondary-light);
-        --accent: var(--accent-light);
-        --border-color: var(--border-color-light);
-        --error-color: var(--error-color-light);
       }
       [data-theme="dark"] {
         --bg-primary: var(--bg-primary-dark);
@@ -569,7 +553,6 @@
         }
         .nav-links.active { right: 0; }
         .nav-links li { text-align: center; }
-        .nav-links a, #theme-toggle { font-size: 1.2rem; }
+        .nav-links a { font-size: 1.2rem; }
         .menu-toggle { display: flex; }
-        .theme-toggle-text { display: inline; }
       }

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -15,10 +15,6 @@
           "form-error-container",
         );
         const formErrorText = document.getElementById("form-error-text");
-        const themeToggle = document.getElementById("theme-toggle");
-        const sunIcon = document.getElementById("theme-icon-sun");
-        const moonIcon = document.getElementById("theme-icon-moon");
-        const htmlEl = document.documentElement;
 
         // --- Конфигурация ---
         const BASE_URL = "https://port.radilov-k.workers.dev";
@@ -58,26 +54,7 @@
           }
         }
 
-        // --- Управление на Темата ---
-        function applyTheme(theme) {
-          htmlEl.setAttribute("data-theme", theme);
-          if (sunIcon) {
-            sunIcon.style.display = theme === "dark" ? "block" : "none";
-          }
-          if (moonIcon) {
-            moonIcon.style.display = theme === "light" ? "block" : "none";
-          }
-        }
-        const savedTheme = localStorage.getItem("theme") || "dark";
-        applyTheme(savedTheme);
-        if (themeToggle) {
-          themeToggle.addEventListener("click", () => {
-            const newTheme =
-              htmlEl.getAttribute("data-theme") === "dark" ? "light" : "dark";
-            localStorage.setItem("theme", newTheme);
-            applyTheme(newTheme);
-          });
-        }
+
 
         // --- Мобилно меню ---
         const menuToggle = document.querySelector(".menu-toggle");
@@ -103,9 +80,7 @@
         if (navLinksContainer) {
           navLinksContainer.addEventListener("click", (e) => {
             if (e.target.tagName === "A" || e.target.closest("button")) {
-              if (!e.target.closest("#theme-toggle")) {
-                closeMenu();
-              }
+              closeMenu();
             }
           });
         }

--- a/src/admin.html
+++ b/src/admin.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <button id="theme-toggle" aria-label="Смени тема">🌞</button>
 
     <h1>Настройки на продукта</h1>
     <label>

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <button id="theme-toggle" aria-label="Смени тема">🌞</button>
 
     <h1>Продукт</h1>
     <div id="product">

--- a/src/script.js
+++ b/src/script.js
@@ -1,17 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const toggle = document.getElementById('theme-toggle');
-
-    if (localStorage.getItem('theme') === 'dark') {
-        document.body.classList.add('dark');
-        toggle.textContent = '🌚';
-    }
-
-    toggle.addEventListener('click', () => {
-        document.body.classList.toggle('dark');
-        const dark = document.body.classList.contains('dark');
-        toggle.textContent = dark ? '🌚' : '🌞';
-        localStorage.setItem('theme', dark ? 'dark' : 'light');
-    });
 
     const priceSpan = document.getElementById('product-price');
     if (priceSpan) {

--- a/src/style.css
+++ b/src/style.css
@@ -1,18 +1,6 @@
 body {
     font-family: Arial, sans-serif;
-    transition: background-color 0.3s, color 0.3s;
-    background-color: #fff;
-    color: #000;
-}
-
-body.dark {
     background-color: #222;
     color: #f4f4f4;
-}
-
-button#theme-toggle {
-    border: none;
-    background: none;
-    cursor: pointer;
-    font-size: 1.5rem;
+    transition: background-color 0.3s, color 0.3s;
 }


### PR DESCRIPTION
## Summary
- remove the theme switcher and all light-theme CSS
- keep HTML pages in dark theme by default
- clean up related JS logic for toggling themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d9b84f8f083269c9c5018584a34ad