### PR TITLE
Добавени отделни файлове за съдържание и продукти

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -3,7 +3,7 @@
 // =======================================================
 
 // API Endpoint
-import { fetchPageContent, fetchOrders, savePageContent, updateOrderStatus } from "./js/api.js";
+import { fetchSiteContent, fetchProducts, fetchOrders, saveSiteContent, saveProducts, updateOrderStatus } from "./js/api.js";
 
 // Централизирани DOM елементи
 const DOM = {
@@ -60,10 +60,14 @@ let currentModalSaveCallback = null;
 
 async function fetchData() {
     try {
-        return await fetchPageContent();
+        const [site, products] = await Promise.all([
+            fetchSiteContent(),
+            fetchProducts()
+        ]);
+        return { ...site, page_content: [...(site.page_content || []), ...(products.product_categories || [])] };
     } catch (error) {
         showNotification('Критична грешка при зареждане на данните.', 'error');
-        console.error('Грешка при зареждане на page_content:', error);
+        console.error('Грешка при зареждане на съдържание:', error);
         return null;
     }
 }
@@ -89,7 +93,16 @@ async function saveData() {
     DOM.saveStatus.className = 'save-status is-saving';
 
     try {
-        await savePageContent(appData);
+        const { marketing, catalog } = separateContent(appData.page_content);
+        await Promise.all([
+            saveSiteContent({
+                settings: appData.settings,
+                navigation: appData.navigation,
+                page_content: marketing,
+                footer: appData.footer
+            }),
+            saveProducts({ product_categories: catalog })
+        ]);
         setUnsavedChanges(false);
         showNotification('Промените са записани успешно.', 'success');
     } catch (err) {
@@ -746,6 +759,16 @@ function setProperty(obj, path, value) {
     const last = parts.pop();
     const target = parts.reduce((acc, part) => acc[part] = acc[part] || {}, obj);
     target[last] = value;
+}
+
+function separateContent(components) {
+    const marketing = [];
+    const catalog = [];
+    (components || []).forEach(c => {
+        if (c.type === 'product_category') catalog.push(c);
+        else marketing.push(c);
+    });
+    return { marketing, catalog };
 }
 
 // =======================================================

--- a/index.js
+++ b/index.js
@@ -532,15 +532,22 @@ async function main() {
     initializeGlobalScripts();
     
     try {
-        const response = await fetch(`${API_URL}/page_content.json?v=${Date.now()}`);
-        if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
-        const data = await response.json();
+        const [siteRes, prodRes] = await Promise.all([
+            fetch(`${API_URL}/site_content.json?v=${Date.now()}`),
+            fetch(`${API_URL}/products.json?v=${Date.now()}`)
+        ]);
+        if (!siteRes.ok || !prodRes.ok) {
+            throw new Error(`HTTP error!`);
+        }
+        const siteData = await siteRes.json();
+        const prodData = await prodRes.json();
+        const combinedContent = [...(siteData.page_content || []), ...(prodData.product_categories || [])];
 
-        DOM.mainContainer.innerHTML = ''; 
-        
-        renderHeader(data.settings, data.navigation);
-        renderMainContent(data.page_content);
-        renderFooter(data.settings, data.footer);
+        DOM.mainContainer.innerHTML = '';
+
+        renderHeader(siteData.settings, siteData.navigation);
+        renderMainContent(combinedContent);
+        renderFooter(siteData.settings, siteData.footer);
         
         DOM.mainContainer.classList.add('is-loaded');
 

--- a/js/api.js
+++ b/js/api.js
@@ -1,13 +1,29 @@
 import { API_URL } from '../config.js';
 
-export async function fetchPageContent() {
-    const response = await fetch(`${API_URL}/page_content.json?v=${Date.now()}`);
+export async function fetchSiteContent() {
+    const response = await fetch(`${API_URL}/site_content.json?v=${Date.now()}`);
     if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
     return response.json();
 }
 
-export async function savePageContent(data) {
-    const response = await fetch(`${API_URL}/page_content.json`, {
+export async function saveSiteContent(data) {
+    const response = await fetch(`${API_URL}/site_content.json`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data, null, 2)
+    });
+    if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
+    return response.json();
+}
+
+export async function fetchProducts() {
+    const response = await fetch(`${API_URL}/products.json?v=${Date.now()}`);
+    if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
+    return response.json();
+}
+
+export async function saveProducts(data) {
+    const response = await fetch(`${API_URL}/products.json`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data, null, 2)

--- a/kv/products.json
+++ b/kv/products.json
@@ -1,0 +1,780 @@
+{
+  "product_categories": [
+    {
+      "type": "product_category",
+      "component_id": "comp-uuid-prodcat-001",
+      "id": "anti-aging",
+      "title": "Anti-Aging & Клетъчна Регенерация",
+      "image": "https://raw.githubusercontent.com/Radilovk/face/main/assets/ChatGPT%20Image%20Jul%205,%202025,%2007_00_41%20PM.png",
+      "options": {
+        "is_collapsible": true,
+        "is_expanded_by_default": true
+      },
+      "products": [
+        {
+          "product_id": "prod-epitalon",
+          "public_data": {
+            "name": "Epitalon",
+            "tagline": "Ключът към удължаване на теломерите",
+            "price": 0,
+            "description": "Рестартирайте биологичния си часовник. Epitalon е революционен тетрапептид, който активира ензима теломераза, за да предпази и удължи теломерите, които са ключови за клетъчното стареене.",
+            "image_url": "/images/products/epitalon.png",
+            "research_note": {
+              "text": "Bulletin of Experimental Biology 2003",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Epitalon+telomerase+2003"
+            },
+            "effects": [
+              {
+                "label": "Активиране на Теломераза",
+                "value": 95
+              },
+              {
+                "label": "Регулация на Циркаден Ритъм",
+                "value": 85
+              },
+              {
+                "label": "Имунна Модулация",
+                "value": 75
+              }
+            ],
+            "variants": [
+              {
+                "title": "Epitalon 20 mg (прах)",
+                "description": "Стандартна доза.",
+                "url": "https://www.peptidesciences.com/epithalon-epitalon-20mg"
+              },
+              {
+                "title": "Epitalon 50 mg (прах)",
+                "description": "По-висока концентрация.",
+                "url": "https://www.peptidesciences.com/epithalon-epitalon-50mg"
+              },
+              {
+                "title": "N-Acetyl Epithalon Amidate 20 mg",
+                "description": "Амидирана, по-стабилна форма.",
+                "url": "https://www.peptidesciences.com/n-acetyl-epithalon-amidate-20mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "anti-aging",
+              "longevity",
+              "immune-support"
+            ],
+            "target_profile": "Хора, търсещи превантивни анти-ейджинг стратегии и подобряване на съня.",
+            "protocol_hint": "Прилага се подкожно или интрамускулно, обикновено в цикли.",
+            "synergy_products": [
+              "prod-nad-plus"
+            ],
+            "safety_warnings": "Да се използва след консултация със специалист. Не се препоръчва при активни онкологични заболявания.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-ghk-cu",
+          "public_data": {
+            "name": "GHK-Cu",
+            "tagline": "Еликсир за кожа и тъкани",
+            "price": 0,
+            "description": "Подарете на кожата си плътност и блясък. GHK-Cu (меден пептид) мощно стимулира производството на колаген, изглажда фините линии и ускорява регенерацията на тъкани в цялото тяло.",
+            "image_url": "/images/products/ghk-cu.png",
+            "research_note": {
+              "text": "Journal of Cosmetic Dermatology 2020",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=GHK-Cu+skin+2020"
+            },
+            "effects": [
+              {
+                "label": "Синтез на Колаген и Еластин",
+                "value": 90
+              },
+              {
+                "label": "Регенерация на Кожа и Тъкани",
+                "value": 95
+              },
+              {
+                "label": "Противовъзпалителен Ефект",
+                "value": 80
+              }
+            ],
+            "variants": [
+              {
+                "title": "GHK-Cu 50 mg (прах)",
+                "description": "За системно инжекционно приложение.",
+                "url": "https://www.peptidesciences.com/ghk-cu-50mg-copper-peptide"
+              },
+              {
+                "title": "GHK-Cu 2 mg / 60 капсули",
+                "description": "Удобна орална форма.",
+                "url": "https://www.peptidesciences.com/ghk-cu-copper-tripeptide"
+              },
+              {
+                "title": "GHK-Cu 200 mg (крем)",
+                "description": "За локално третиране на кожата.",
+                "url": "https://www.peptidesciences.com/ghk-ghk-cu-200mg-topical"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable / Oral / Topical",
+            "goals": [
+              "skin-health",
+              "anti-aging",
+              "wound-healing"
+            ],
+            "target_profile": "Потребители, целящи подобряване на състоянието на кожата, косата и обща регенерация.",
+            "protocol_hint": "Приложението зависи от формата - локално за кожа, системно за общи ползи.",
+            "synergy_products": [],
+            "safety_warnings": "Високи дози могат да нарушат медния баланс. Консултирайте се със специалист.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-nad-plus",
+          "public_data": {
+            "name": "NAD⁺",
+            "tagline": "Горивото на живота",
+            "price": 0,
+            "description": "Заредете клетките си с енергия. NAD⁺ е жизненоважен коензим, който захранва митохондриите, активира гените на дълголетието (Sirtuins) и е ключов за ремонта на ДНК.",
+            "image_url": "/images/products/nad-plus.png",
+            "research_note": {
+              "text": "Nature Metabolism 2019",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=NAD%2B+metabolism+2019"
+            },
+            "effects": [
+              {
+                "label": "Клетъчна Енергия и Метаболизъм",
+                "value": 95
+              },
+              {
+                "label": "ДНК Възстановяване",
+                "value": 85
+              },
+              {
+                "label": "Активиране на Сиртуини",
+                "value": 90
+              }
+            ],
+            "variants": [
+              {
+                "title": "NAD⁺ 1000 mg (IV/SQ/IM)",
+                "description": "Стерилен флакон от NAD MEDICA.",
+                "url": "https://www.nadmedica.com/product/nad-1000mg/"
+              },
+              {
+                "title": "NAD⁺ Home Injection Kit",
+                "description": "Комплект за курс от NAD MEDICA.",
+                "url": "https://www.nadmedica.com/product/nad-home-kit/"
+              },
+              {
+                "title": "NAD⁺ 750 mg (прах)",
+                "description": "Лиофилизат от PEPTIDE SCIENCES.",
+                "url": "https://www.peptidesciences.com/nadplus-750mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable (IV/SQ/IM)",
+            "goals": [
+              "longevity",
+              "energy",
+              "metabolism",
+              "detox"
+            ],
+            "target_profile": "Всеки, който иска да повиши клетъчната си енергия, да подобри метаболизма и да подпомогне дълголетието.",
+            "protocol_hint": "Подкожните инжекции са най-достъпният метод за домашна употреба. IV инфузиите осигуряват 100% бионаличност.",
+            "synergy_products": [
+              "prod-epitalon"
+            ],
+            "safety_warnings": "Бързото IV вливане може да причини дискомфорт. Да се прилага от медицинско лице.",
+            "inventory": 20
+          }
+        }
+      ]
+    },
+    {
+      "type": "product_category",
+      "component_id": "comp-uuid-prodcat-002",
+      "id": "neuro",
+      "title": "Невропептиди & Ноотропици",
+      "image": "https://raw.githubusercontent.com/Radilovk/face/main/assets/ChatGPT%20Image%20Jul%205,%202025,%2006_28_24%20PM.png",
+      "options": {
+        "is_collapsible": true,
+        "is_expanded_by_default": false
+      },
+      "products": [
+        {
+          "product_id": "prod-semax",
+          "public_data": {
+            "name": "Semax",
+            "tagline": "Когнитивен ускорител",
+            "price": 0,
+            "description": "Отключете пълния си умствен потенциал. Semax повишава нивата на BDNF, което стимулира растежа на нови неврони, подобрява паметта, фокуса и скоростта на мисълта.",
+            "image_url": "/images/products/semax.png",
+            "research_note": {
+              "text": "Bulletin of Experimental Biology 2012",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Semax+cognitive+2012"
+            },
+            "effects": [
+              {
+                "label": "Фокус и Концентрация",
+                "value": 90
+              },
+              {
+                "label": "BDNF Стимулация (Неврогенеза)",
+                "value": 95
+              },
+              {
+                "label": "Невропротекция",
+                "value": 80
+              }
+            ],
+            "variants": [
+              {
+                "title": "Semax 30 mg (прах)",
+                "description": "За интраназално приложение.",
+                "url": "https://www.peptidesciences.com/semax-30mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Intranasal",
+            "goals": [
+              "cognitive",
+              "focus",
+              "memory"
+            ],
+            "target_profile": "Студенти, професионалисти и всеки, който иска да подобри когнитивните си функции.",
+            "protocol_hint": "Прилага се като спрей за нос. Обикновено 1-2 впръсквания във всяка ноздра сутрин.",
+            "synergy_products": [
+              "prod-selank"
+            ],
+            "safety_warnings": "Да се съхранява в хладилник след разтваряне. Консултирайте се със специалист.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-selank",
+          "public_data": {
+            "name": "Selank",
+            "tagline": "Спокойствие и устойчивост",
+            "price": 0,
+            "description": "Естествено решение срещу стрес и тревожност. Selank модулира нивата на GABA и енкефалини в мозъка, което води до усещане за спокойствие и емоционална стабилност, без седация.",
+            "image_url": "/images/products/selank.png",
+            "research_note": {
+              "text": "European Neuropsychopharmacology 2015",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Selank+anxiety+2015"
+            },
+            "effects": [
+              {
+                "label": "Анксиолитичен Ефект (Анти-стрес)",
+                "value": 90
+              },
+              {
+                "label": "Подобряване на Настроението",
+                "value": 80
+              },
+              {
+                "label": "Когнитивна Подкрепа",
+                "value": 70
+              }
+            ],
+            "variants": [
+              {
+                "title": "Selank 10 mg (прах)",
+                "description": "За интраназално приложение.",
+                "url": "https://www.peptidesciences.com/selank-10mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Intranasal",
+            "goals": [
+              "anti-stress",
+              "anxiety-relief",
+              "mood-support"
+            ],
+            "target_profile": "Хора, подложени на ежедневен стрес, или страдащи от лека до умерена тревожност.",
+            "protocol_hint": "Прилага се като спрей за нос. Може да се използва ежедневно или при нужда.",
+            "synergy_products": [
+              "prod-semax"
+            ],
+            "safety_warnings": "Да се съхранява в хладилник след разтваряне. Консултирайте се със специалист.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-dsip",
+          "public_data": {
+            "name": "DSIP",
+            "tagline": "Дълбок и възстановяващ сън",
+            "price": 0,
+            "description": "Оптимизирайте най-важния процес за регенерация. DSIP (Delta Sleep-Inducing Peptide) насърчава навлизането в дълбоките фази на съня (slow-wave sleep) и нормализира циркадните ритми.",
+            "image_url": "/images/products/dsip.png",
+            "research_note": {
+              "text": "Sleep Research 1988",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Delta+Sleep-Inducing+Peptide+1988"
+            },
+            "effects": [
+              {
+                "label": "Подобряване Качеството на Съня",
+                "value": 85
+              },
+              {
+                "label": "Намаляване на Стреса",
+                "value": 70
+              },
+              {
+                "label": "Нормализиране на Ритмите",
+                "value": 60
+              }
+            ],
+            "variants": [
+              {
+                "title": "DSIP 5 mg (прах)",
+                "description": "За инжекционно приложение преди сън.",
+                "url": "https://www.peptidesciences.com/delta-sleep-inducing-peptide"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "sleep-quality",
+              "recovery"
+            ],
+            "target_profile": "Хора с проблеми със съня, работещи на смени или пътуващи често.",
+            "protocol_hint": "Прилага се подкожно около 30-60 минути преди лягане.",
+            "synergy_products": [
+              "prod-epitalon"
+            ],
+            "safety_warnings": "Може да предизвика сънливост. Не шофирайте след употреба. Консултирайте се със специалист.",
+            "inventory": 20
+          }
+        }
+      ]
+    },
+    {
+      "type": "product_category",
+      "component_id": "cat_165890",
+      "id": "growth",
+      "title": "Растеж, Метаболизъм & Възстановяване",
+      "image": "https://raw.githubusercontent.com/Radilovk/face/main/assets/ChatGPT%20Image%20Jul%205,%202025,%2007_31_47%20PM.png",
+      "options": {
+        "is_collapsible": true,
+        "is_expanded_by_default": false
+      },
+      "products": [
+        {
+          "product_id": "prod-tb-500",
+          "public_data": {
+            "name": "TB-500",
+            "tagline": "Системно заздравяване",
+            "price": 0,
+            "description": "Синтетичен вариант на Thymosin Beta-4, естествен протеин, който играе ключова роля в регенерацията на тъкани. Ускорява възстановяването на мускули, сухожилия, стави и кожа.",
+            "image_url": "/images/products/tb-500.png",
+            "research_note": {
+              "text": "Annals of NY Academy of Sciences 2010",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Thymosin+Beta+4+regeneration+2010"
+            },
+            "effects": [
+              {
+                "label": "Възстановяване на Меки Тъкани",
+                "value": 90
+              },
+              {
+                "label": "Намаляване на Възпалението",
+                "value": 80
+              },
+              {
+                "label": "Подобряване на Гъвкавостта",
+                "value": 70
+              }
+            ],
+            "variants": [
+              {
+                "title": "TB-500 10 mg (прах)",
+                "description": "Висока доза за ефективни протоколи.",
+                "url": "https://www.peptidesciences.com/tb-500-10mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "recovery",
+              "injury-repair",
+              "anti-inflammatory"
+            ],
+            "target_profile": "Спортисти, хора с хронични или остри травми на меките тъкани.",
+            "protocol_hint": "Прилага се подкожно. Често се използва зареждаща фаза, последвана от поддържаща.",
+            "synergy_products": [
+              "prod-ghk-cu"
+            ],
+            "safety_warnings": "Да се използва след консултация със специалист.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-cjc-1295-no-dac",
+          "public_data": {
+            "name": "CJC-1295 no DAC",
+            "tagline": "Пулсова GH стимулация",
+            "price": 0,
+            "description": "Модифициран аналог на GHRH, който стимулира хипофизата да освобождава растежен хормон (GH) в естествени, физиологични пулсации. Идеален за комбиниране с GHRP пептиди.",
+            "image_url": "/images/products/cjc-1295.png",
+            "research_note": {
+              "text": "Journal of Clinical Endocrinology 2006",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=CJC-1295+GHRH+2006"
+            },
+            "effects": [
+              {
+                "label": "Стимулация на Растежен Хормон (GH)",
+                "value": 85
+              },
+              {
+                "label": "Покачване на Мускулна Маса",
+                "value": 70
+              },
+              {
+                "label": "Намаляване на Мазнини",
+                "value": 65
+              }
+            ],
+            "variants": [
+              {
+                "title": "CJC-1295 No DAC 5 mg (прах)",
+                "description": "Стандартна доза.",
+                "url": "https://www.peptidesciences.com/mod-grf-1-29-5mg-cjc-1295-no-dac"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "muscle-growth",
+              "fat-loss",
+              "anti-aging"
+            ],
+            "target_profile": "Фитнес ентусиасти, бодибилдъри и хора, търсещи анти-ейджинг ефекти от повишен GH.",
+            "protocol_hint": "Работи най-добре в комбинация с GHRP като Ipamorelin, за да се постигне синергичен ефект.",
+            "synergy_products": [
+              "prod-ipamorelin"
+            ],
+            "safety_warnings": "Да се прилага на празен стомах за максимален ефект. Консултирайте се със специалист.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-ipamorelin",
+          "public_data": {
+            "name": "Ipamorelin",
+            "tagline": "Селективна GH стимулация",
+            "price": 0,
+            "description": "Един от най-селективните GH секретагози. Стимулира освобождаването на GH с минимално или никакво въздействие върху нивата на кортизол и пролактин, което го прави идеален за анти-ейджинг.",
+            "image_url": "/images/products/ipamorelin.png",
+            "research_note": {
+              "text": "Growth Hormone & IGF Research 2001",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Ipamorelin+GH+2001"
+            },
+            "effects": [
+              {
+                "label": "Селективна GH Стимулация",
+                "value": 80
+              },
+              {
+                "label": "Минимално Въздействие на Кортизол",
+                "value": 95
+              },
+              {
+                "label": "Подобряване на Съня",
+                "value": 70
+              }
+            ],
+            "variants": [
+              {
+                "title": "Ipamorelin 5 mg (прах)",
+                "description": "Висококачествен пептид.",
+                "url": "https://www.peptidesciences.com/ipamorelin-5mg"
+              },
+              {
+                "title": "CJC-1295/Ipamorelin 10 mg (Бленд)",
+                "description": "Синергична комбинация.",
+                "url": "https://www.peptidesciences.com/cjc-1295-ipamorelin-10mg-blend"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "anti-aging",
+              "fat-loss",
+              "sleep-quality"
+            ],
+            "target_profile": "Потребители, които искат ползите от GH без странични ефекти като повишен кортизол.",
+            "protocol_hint": "Често се комбинира с CJC-1295 no DAC. Прилага се преди лягане за синхронизация с естествения GH пулс.",
+            "synergy_products": [
+              "prod-cjc-1295-no-dac"
+            ],
+            "safety_warnings": "Консултирайте се със специалист.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-fragment-176-191",
+          "public_data": {
+            "name": "Fragment 176-191",
+            "tagline": "Изгаряне на мазнини",
+            "price": 0,
+            "description": "Специализиран фрагмент от молекулата на растежния хормон, отговорен само за липолизата. Ускорява метаболизма на мазнините и инхибира създаването на нови мастни клетки.",
+            "image_url": "/images/products/fragment-176-191.png",
+            "research_note": {
+              "text": "Obesity Research 2004",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=hGH+Fragment+176-191+lipolysis+2004"
+            },
+            "effects": [
+              {
+                "label": "Насочено Изгаряне на Мазнини",
+                "value": 90
+              },
+              {
+                "label": "Инхибиране на Липогенезата",
+                "value": 85
+              },
+              {
+                "label": "Без Ефект върху Кръвната Захар",
+                "value": 100
+              }
+            ],
+            "variants": [
+              {
+                "title": "Fragment 176-191 5 mg (прах)",
+                "description": "Оптимална доза за изгаряне на мазнини.",
+                "url": "https://www.peptidesciences.com/fragment-176-191-5mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "fat-loss"
+            ],
+            "target_profile": "Хора, които искат да намалят телесните мазнини без стимулиращия ефект на други фет-бърнъри.",
+            "protocol_hint": "Прилага се подкожно, обикновено сутрин на гладно или преди тренировка.",
+            "synergy_products": [],
+            "safety_warnings": "Консултирайте се със специалист.",
+            "inventory": 20
+          }
+        }
+      ]
+    },
+    {
+      "type": "product_category",
+      "component_id": "cat_165891",
+      "id": "lifestyle",
+      "title": "Лайфстайл, Либидо & Естетика",
+      "image": "https://raw.githubusercontent.com/Radilovk/face/main/assets/ChatGPT%20Image%20Jul%205,%202025,%2009_16_33%20PM.png",
+      "options": {
+        "is_collapsible": false,
+        "is_expanded_by_default": true
+      },
+      "products": [
+        {
+          "product_id": "prod-pt-141",
+          "public_data": {
+            "name": "PT-141",
+            "tagline": "Централен стимул за либидото",
+            "price": 0,
+            "description": "Уникален пептид, който действа директно върху меланокортиновите рецептори в мозъка, за да повиши сексуалното желание и възбуда както при мъже, така и при жени.",
+            "image_url": "/images/products/pt-141.png",
+            "research_note": {
+              "text": "Journal of Sexual Medicine 2020",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Bremelanotide+PT-141+libido+2020"
+            },
+            "effects": [
+              {
+                "label": "Повишаване на Либидото",
+                "value": 95
+              },
+              {
+                "label": "Еректилна Функция",
+                "value": 85
+              },
+              {
+                "label": "Действие върху Нервната С-ма",
+                "value": 90
+              }
+            ],
+            "variants": [
+              {
+                "title": "PT-141 10 mg (прах)",
+                "description": "За интраназално/инжекционно приложение.",
+                "url": "https://www.peptidesciences.com/pt-141-10mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Intranasal / Injectable",
+            "goals": [
+              "libido",
+              "sexual-health"
+            ],
+            "target_profile": "Мъже и жени, изпитващи намалено либидо.",
+            "protocol_hint": "Прилага се при нужда, около 1-2 часа преди очаквания ефект.",
+            "synergy_products": [
+              "prod-kisspeptin-10"
+            ],
+            "safety_warnings": "Може да предизвика временно гадене или зачервяване на лицето. Не се препоръчва при сърдечно-съдови проблеми.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-melanotan-1",
+          "public_data": {
+            "name": "Melanotan I",
+            "tagline": "Естествен тен с висока селективност",
+            "price": 0,
+            "description": "Стимулира производството на меланин за постигане на естествен тен, като предлага по-селективно действие и по-малко странични ефекти в сравнение с Melanotan II.",
+            "image_url": "/images/products/melanotan-1.png",
+            "research_note": {
+              "text": "Archives of Dermatology 2009",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Melanotan+I+afamelanotide+2009"
+            },
+            "effects": [
+              {
+                "label": "Стимулация на Кожен Тен",
+                "value": 95
+              },
+              {
+                "label": "UV Защита",
+                "value": 90
+              },
+              {
+                "label": "Минимални странични ефекти",
+                "value": 90
+              }
+            ],
+            "variants": [
+              {
+                "title": "Melanotan I 10 mg (прах)",
+                "description": "По-селективен вариант за тен.",
+                "url": "https://www.peptidesciences.com/melanotan-1-10mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "aesthetics",
+              "tanning",
+              "uv-protection"
+            ],
+            "target_profile": "Хора със светла кожа, които искат безопасен тен и UV защита.",
+            "protocol_hint": "Използва се в ниски дози ежедневно до достигане на желания тен, след което се преминава на поддържаща доза.",
+            "synergy_products": [],
+            "safety_warnings": "По-малко странични ефекти от MT-II. Препоръчва се преглед на бенките преди употреба.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-melanotan-2",
+          "public_data": {
+            "name": "Melanotan II",
+            "tagline": "Безопасен и дълбок тен",
+            "price": 0,
+            "description": "Постигнете перфектен слънчев загар с минимално излагане на UV лъчи. Melanotan II стимулира производството на меланин. Като страничен ефект може да повиши либидото и да намали апетита.",
+            "image_url": "/images/products/melanotan-2.png",
+            "research_note": {
+              "text": "British Journal of Pharmacology 2000",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Melanotan+II+pigmentation+2000"
+            },
+            "effects": [
+              {
+                "label": "Стимулация на Кожен Тен",
+                "value": 90
+              },
+              {
+                "label": "Повишаване на Либидото",
+                "value": 70
+              },
+              {
+                "label": "Намаляване на Апетита",
+                "value": 60
+              }
+            ],
+            "variants": [
+              {
+                "title": "Melanotan II 10 mg (прах)",
+                "description": "Стандартна доза за протоколи за тен.",
+                "url": "https://www.peptidesciences.com/melanotan-2-10mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "aesthetics",
+              "tanning",
+              "libido"
+            ],
+            "target_profile": "Хора, които търсят бърз и наситен тен, както и потенциално повишаване на либидото.",
+            "protocol_hint": "Започва се с много ниска доза, за да се оцени толерантността към страничните ефекти.",
+            "synergy_products": [],
+            "safety_warnings": "Чести странични ефекти включват гадене, зачервяване, спонтанни ерекции. Препоръчва се преглед на бенките преди употреба.",
+            "inventory": 20
+          }
+        },
+        {
+          "product_id": "prod-kisspeptin-10",
+          "public_data": {
+            "name": "Kisspeptin-10",
+            "tagline": "Регулатор на репродукцията",
+            "price": 0,
+            "description": "Основен регулатор на оста хипоталамус-хипофиза-гонади. Kisspeptin-10 е мощен стимулатор на освобождаването на GnRH, което от своя страна води до продукция на LH и FSH.",
+            "image_url": "/images/products/kisspeptin-10.png",
+            "research_note": {
+              "text": "Human Reproduction Update 2014",
+              "url": "https://pubmed.ncbi.nlm.nih.gov/?term=Kisspeptin-10+reproduction+2014"
+            },
+            "effects": [
+              {
+                "label": "Стимулация на LH/FSH",
+                "value": 85
+              },
+              {
+                "label": "Регулация на Репродуктивна Ос",
+                "value": 90
+              },
+              {
+                "label": "Влияние върху Настроението",
+                "value": 65
+              }
+            ],
+            "variants": [
+              {
+                "title": "Kisspeptin-10 5 mg (прах)",
+                "description": "За изследователски протоколи.",
+                "url": "https://www.peptidesciences.com/kisspeptin-10-5mg"
+              }
+            ]
+          },
+          "system_data": {
+            "application_type": "Injectable",
+            "goals": [
+              "libido",
+              "fertility",
+              "hormone-regulation"
+            ],
+            "target_profile": "Използва се при протоколи за възстановяване на репродуктивната ос (PCT) или за стимулиране на либидото.",
+            "protocol_hint": "Има кратък полуживот и се инжектира често, понякога в комбинация с други пептиди.",
+            "synergy_products": [
+              "prod-pt-141"
+            ],
+            "safety_warnings": "Използването му трябва да бъде внимателно наблюдавано от специалист поради силното му въздействие върху хормоналната ос.",
+            "inventory": 20
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/kv/site_content.json
+++ b/kv/site_content.json
@@ -1,0 +1,115 @@
+{
+  "settings": {
+    "site_name": "BIOCODE",
+    "site_slogan": "the science of life",
+    "logo_url": "https://radilovk.github.io/face/assets/logo.png"
+  },
+  "navigation": [
+    {
+      "text": "Anti-Aging",
+      "link": "#anti-aging"
+    },
+    {
+      "text": "Невропептиди",
+      "link": "#neuro"
+    },
+    {
+      "text": "Растеж",
+      "link": "#growth"
+    },
+    {
+      "text": "Лайфстайл",
+      "link": "#lifestyle"
+    },
+    {
+      "text": "За нас",
+      "link": "#about-us"
+    }
+  ],
+  "page_content": [
+    {
+      "type": "info_card",
+      "component_id": "comp-uuid-infocard-001",
+      "id": "about-us",
+      "title": "Науката зад BIOCODE",
+      "image": "https://radilovk.github.io/face/assets/scientist-holding-medical-testing-tubes-600nw-2506585825.webp",
+      "content": "Нашата мисия е да демистифицираме света на регенеративната медицина. Всеки продукт в нашето портфолио е подкрепен от научни изследвания и е избран заради неговия потенциал да оптимизира човешкото здраве на клетъчно ниво.\n\nНие вярваме в информирания избор и предоставяме прозрачна информация, за да можете да вземете най-доброто решение за вашето тяло и ум.",
+      "button": {
+        "text": "Разгледай изследванията",
+        "url": "https://pubmed.ncbi.nlm.nih.gov/"
+      },
+      "options": {
+        "image_align": "right"
+      }
+    },
+    {
+      "type": "hero_banner",
+      "component_id": "comp-uuid-hero-001",
+      "title": "Интерактивно Портфолио",
+      "subtitle": "Пептиди и Регенеративна Медицина"
+    },
+    {
+      "title": "BIOCODE - индивидуален анализатор",
+      "image": "https://radilovk.github.io/face/assets/analyzis.png",
+      "content": "Създай индивидуален протокол и препоръки",
+      "button": {
+        "text": "Начало",
+        "url": "https://radilovk.github.io/port/quest.html"
+      },
+      "options": {
+        "image_align": "right"
+      },
+      "type": "info_card",
+      "component_id": "comp_1752287788540"
+    }
+  ],
+  "footer": {
+    "columns": [
+      {
+        "type": "logo",
+        "title": ""
+      },
+      {
+        "type": "links",
+        "title": "Бързи Връзки",
+        "links": [
+          {
+            "text": "Начало",
+            "url": "#"
+          },
+          {
+            "text": "Anti-Aging",
+            "url": "#anti-aging"
+          },
+          {
+            "text": "Невропептиди",
+            "url": "#neuro"
+          },
+          {
+            "text": "Растеж",
+            "url": "#growth"
+          }
+        ]
+      },
+      {
+        "type": "links",
+        "title": "Информация",
+        "links": [
+          {
+            "text": "За нас",
+            "url": "#about-us"
+          },
+          {
+            "text": "Контакти",
+            "url": "#contact"
+          },
+          {
+            "text": "Политика за поверителност",
+            "url": "/privacy"
+          }
+        ]
+      }
+    ],
+    "copyright_text": "© 2025 BIOCODE. Всички права запазени."
+  }
+}

--- a/local/handler.js
+++ b/local/handler.js
@@ -69,13 +69,13 @@ export async function handleRequest(request, env) {
           headers: corsHeaders
         });
     }
-  } else if (url.pathname === '/page_content.json') {
+  } else if (url.pathname === '/site_content.json' || url.pathname === '/page_content.json') {
     switch (method) {
       case 'GET': {
-        let data = await env.PAGE_CONTENT.get('page_content');
+        let data = await env.PAGE_CONTENT.get('site_content');
         if (data === null) {
           data = '{}';
-          await env.PAGE_CONTENT.put('page_content', data);
+          await env.PAGE_CONTENT.put('site_content', data);
         }
         return new Response(data, {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
@@ -91,7 +91,7 @@ export async function handleRequest(request, env) {
           });
         }
         const text = await request.text();
-        await env.PAGE_CONTENT.put('page_content', text);
+        await env.PAGE_CONTENT.put('site_content', text);
         return new Response(JSON.stringify({ status: 'ok' }), {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });
@@ -101,6 +101,32 @@ export async function handleRequest(request, env) {
           status: 405,
           headers: corsHeaders
         });
+    }
+  } else if (url.pathname === '/products.json') {
+    switch (method) {
+      case 'GET': {
+        let data = await env.PAGE_CONTENT.get('products');
+        if (data === null) {
+          data = '{"product_categories":[]}'
+          await env.PAGE_CONTENT.put('products', data);
+        }
+        return new Response(data, { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+      case 'POST': {
+        try {
+          await request.clone().json();
+        } catch (e) {
+          return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+            status: 400,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+          });
+        }
+        const text = await request.text();
+        await env.PAGE_CONTENT.put('products', text);
+        return new Response(JSON.stringify({ status: 'ok' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+      default:
+        return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
     }
   }
 

--- a/local/local-worker.js
+++ b/local/local-worker.js
@@ -23,16 +23,22 @@ const env = {
   },
   PAGE_CONTENT: {
     async get(key) {
+      const file = key === 'products' ? './products.json'
+                 : key === 'site_content' ? './site_content.json'
+                 : './page_content.json';
       try {
-        return await fs.readFile('./page_content.json', 'utf8');
+        return await fs.readFile(file, 'utf8');
       } catch {
-        const init = '{}';
-        await fs.writeFile('./page_content.json', init);
+        const init = key === 'products' ? '{"product_categories":[]}' : '{}';
+        await fs.writeFile(file, init);
         return init;
       }
     },
     async put(key, value) {
-      await fs.writeFile('./page_content.json', value);
+      const file = key === 'products' ? './products.json'
+                 : key === 'site_content' ? './site_content.json'
+                 : './page_content.json';
+      await fs.writeFile(file, value);
     }
   }
 };

--- a/tests/handler.test.js
+++ b/tests/handler.test.js
@@ -71,34 +71,19 @@ describe('orders endpoint', () => {
   });
 });
 
-function createContentEnv(initial = '{}') {
-  let stored = initial;
-  return {
-    PAGE_CONTENT: {
-      async get() { return stored; },
-      async put(_key, value) { stored = value; }
-    },
-    ORDERS: {
-      async get() { return '[]'; },
-      async put() {}
-    },
-    getStored() { return stored; }
-  };
-}
-
-describe('page_content endpoint', () => {
-  test('GET /page_content.json returns data', async () => {
-    const env = createContentEnv('{"title":"Demo"}');
-    const req = new Request('http://localhost/page_content.json', { method: 'GET' });
+describe('products endpoint', () => {
+  test('GET /products.json returns data', async () => {
+    const env = createContentEnv('{"product_categories":[]}');
+    const req = new Request('http://localhost/products.json', { method: 'GET' });
     const res = await handleRequest(req, env);
     expect(res.status).toBe(200);
-    expect(await res.text()).toBe('{"title":"Demo"}');
+    expect(await res.text()).toBe('{"product_categories":[]}');
   });
 
-  test('POST /page_content.json updates data', async () => {
+  test('POST /products.json updates data', async () => {
     const env = createContentEnv();
-    const payload = { title: 'New' };
-    const req = new Request('http://localhost/page_content.json', {
+    const payload = { product_categories: [{ id: 1 }] };
+    const req = new Request('http://localhost/products.json', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
@@ -110,9 +95,61 @@ describe('page_content endpoint', () => {
     expect(env.getStored()).toBe(JSON.stringify(payload));
   });
 
-  test('POST /page_content.json with invalid JSON returns error', async () => {
+  test('POST /products.json with invalid JSON returns error', async () => {
     const env = createContentEnv();
-    const req = new Request('http://localhost/page_content.json', {
+    const req = new Request('http://localhost/products.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{invalid}'
+    });
+    const res = await handleRequest(req, env);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json).toEqual({ error: 'Invalid JSON' });
+  });
+});
+function createContentEnv(initial = '{}') {
+  let stored = initial;
+  return {
+    PAGE_CONTENT: {
+      async get(key) { return stored; },
+      async put(_key, value) { stored = value; }
+    },
+    ORDERS: {
+      async get() { return '[]'; },
+      async put() {}
+    },
+    getStored() { return stored; }
+  };
+}
+
+describe('site_content endpoint', () => {
+  test('GET /site_content.json returns data', async () => {
+    const env = createContentEnv('{"title":"Demo"}');
+    const req = new Request('http://localhost/site_content.json', { method: 'GET' });
+    const res = await handleRequest(req, env);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('{"title":"Demo"}');
+  });
+
+  test('POST /site_content.json updates data', async () => {
+    const env = createContentEnv();
+    const payload = { title: 'New' };
+    const req = new Request('http://localhost/site_content.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const res = await handleRequest(req, env);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe('ok');
+    expect(env.getStored()).toBe(JSON.stringify(payload));
+  });
+
+  test('POST /site_content.json with invalid JSON returns error', async () => {
+    const env = createContentEnv();
+    const req = new Request('http://localhost/site_content.json', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '{invalid}'

--- a/worker.js
+++ b/worker.js
@@ -37,13 +37,23 @@ export default {
         case '/quest-submit':
           response = await handleQuestSubmit(request, env, ctx);
           break;
-        
-        case '/page_content.json':
-          // Този ендпойнт вече ще обработва GET и POST
+
+        case '/site_content.json':
+        case '/page_content.json': // съвместимост
           if (request.method === 'GET') {
-              response = await handleGetPageContent(request, env);
+              response = await handleGetSiteContent(request, env);
           } else if (request.method === 'POST') {
-              response = await handleSavePageContent(request, env, ctx);
+              response = await handleSaveSiteContent(request, env, ctx);
+          } else {
+              throw new UserFacingError('Method Not Allowed.', 405);
+          }
+          break;
+
+        case '/products.json':
+          if (request.method === 'GET') {
+              response = await handleGetProducts(request, env);
+          } else if (request.method === 'POST') {
+              response = await handleSaveProducts(request, env, ctx);
           } else {
               throw new UserFacingError('Method Not Allowed.', 405);
           }
@@ -90,28 +100,58 @@ export default {
 // --- СПЕЦИФИЧНИ ОБРАБОТЧИЦИ НА ЕНДПОЙНТИ ---
 
 /**
- * Handles GET /page_content.json
+ * Handles GET /site_content.json
  */
-async function handleGetPageContent(request, env) {
-    const pageContent = await env.PAGE_CONTENT.get('page_content');
-    if (pageContent === null) {
+async function handleGetSiteContent(request, env) {
+    const siteContent = await env.PAGE_CONTENT.get('site_content');
+    if (siteContent === null) {
         throw new UserFacingError("Content not found.", 404);
     }
-    return new Response(pageContent, {
+    return new Response(siteContent, {
         status: 200,
         headers: { 'Content-Type': 'application/json' }
     });
 }
 
 /**
- * Handles POST /page_content.json
+ * Handles POST /site_content.json
  */
-async function handleSavePageContent(request, env, ctx) {
+async function handleSaveSiteContent(request, env, ctx) {
     const contentToSave = await request.text();
     try {
-        // Проверяваме дали е валиден JSON, преди да запишем
         JSON.parse(contentToSave);
-        ctx.waitUntil(env.PAGE_CONTENT.put('page_content', contentToSave));
+        ctx.waitUntil(env.PAGE_CONTENT.put('site_content', contentToSave));
+        return new Response(JSON.stringify({ success: true, message: 'Content saved.' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    } catch (e) {
+        throw new UserFacingError("Invalid JSON provided in the request body.", 400);
+    }
+}
+
+/**
+ * Handles GET /products.json
+ */
+async function handleGetProducts(request, env) {
+    const products = await env.PAGE_CONTENT.get('products');
+    if (products === null) {
+        throw new UserFacingError("Content not found.", 404);
+    }
+    return new Response(products, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+    });
+}
+
+/**
+ * Handles POST /products.json
+ */
+async function handleSaveProducts(request, env, ctx) {
+    const contentToSave = await request.text();
+    try {
+        JSON.parse(contentToSave);
+        ctx.waitUntil(env.PAGE_CONTENT.put('products', contentToSave));
         return new Response(JSON.stringify({ success: true, message: 'Content saved.' }), {
             status: 200,
             headers: { 'Content-Type': 'application/json' }
@@ -190,11 +230,11 @@ async function handleQuestSubmit(request, env, ctx) {
   
   ctx.waitUntil(saveClientData(env, formData)); // Запазваме данните от въпросника
 
-  const pageContentJSON = await env.PAGE_CONTENT.get('page_content');
+  const pageContentJSON = await env.PAGE_CONTENT.get('products');
   const mainPromptTemplate = await env.PAGE_CONTENT.get('bot_prompt');
-  
+
   if (!pageContentJSON || !mainPromptTemplate) {
-      throw new Error("Critical KV data missing: 'page_content' or 'bot_prompt' not found.");
+      throw new Error("Critical KV data missing: 'products' or 'bot_prompt' not found.");
   }
   
   const productsForAI = transformProductsForAI(JSON.parse(pageContentJSON));
@@ -221,14 +261,19 @@ async function handleQuestSubmit(request, env, ctx) {
 
 // --- AI И ЛОГИКА ЗА ДАННИ ---
 
-function transformProductsForAI(pageContent) {
-  if (!pageContent || !Array.isArray(pageContent.page_content)) {
-    console.error("Invalid pageContent structure for transformation.");
+function transformProductsForAI(data) {
+  let categories = [];
+  if (data && Array.isArray(data.product_categories)) {
+    categories = data.product_categories;
+  } else if (data && Array.isArray(data.page_content)) {
+    categories = data.page_content.filter(c => c.type === 'product_category');
+  } else {
+    console.error("Invalid product data structure for transformation.");
     return [];
   }
-  const allProducts = pageContent.page_content
-    .filter(component => component.type === 'product_category' && Array.isArray(component.products))
-    .flatMap(category => category.products);
+  const allProducts = categories
+    .filter(cat => Array.isArray(cat.products))
+    .flatMap(cat => cat.products);
   return allProducts.map(product => ({
     product_id: product.product_id,
     name: product.public_data.name,


### PR DESCRIPTION
## Резюме
- добавени `kv/site_content.json` и `kv/products.json`
- `/site_content.json` и `/products.json` обслужват съдържанието в `worker.js`
- `index.js` зарежда двата файла поотделно
- `admin.js` разделя маркетинг съдържание и продуктов каталог при запис
- актуализирани локален сървър и тестове

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687da2640c6083269df3306330213ca0