### PR TITLE
Add product page with dynamic content

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -113,9 +113,9 @@ function initializePageInteractions() {
             return;
         }
 
-        const cardHeader = e.target.closest('.product-card .card-header');
-        if (cardHeader && !e.target.closest('.add-to-cart-btn')) {
-            toggleAccordion(cardHeader);
+        const card = e.target.closest('.product-card');
+        if (card && !e.target.closest('.add-to-cart-btn')) {
+            window.location.href = `product.html?id=${card.dataset.productId}`;
             return;
         }
 

--- a/js/product.js
+++ b/js/product.js
@@ -1,0 +1,60 @@
+import { fetchProducts } from './api.js';
+import { addToCart, updateCartCount } from './cart.js';
+import { generateProductCard } from './components/productCard.js';
+
+const DOM = {
+    productContainer: document.getElementById('product-container'),
+    relatedGrid: document.getElementById('related-products-grid'),
+    cartCount: document.getElementById('cart-count')
+};
+
+function renderProduct(product) {
+    const { public_data: pd, system_data: sd } = product;
+    DOM.productContainer.innerHTML = `
+        <h1>${pd.name}</h1>
+        <p>${pd.tagline || ''}</p>
+        ${pd.image_url ? `<img src="${pd.image_url}" alt="${pd.name}" class="product-main-image">` : ''}
+        <p>${pd.description}</p>
+        <section id="product-gallery"></section>
+        <section id="product-reviews"></section>
+        <button class="add-to-cart-btn" data-id="${product.product_id}" data-name="${pd.name}" data-price="${pd.price}" data-inventory="${sd?.inventory ?? 0}">Поръчай</button>
+    `;
+}
+
+function renderRelated(products) {
+    if (!DOM.relatedGrid) return;
+    DOM.relatedGrid.innerHTML = products.slice(0, 4).map(generateProductCard).join('');
+}
+
+async function main() {
+    updateCartCount();
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    if (!id) {
+        DOM.productContainer.textContent = 'Липсва ID на продукт.';
+        return;
+    }
+    try {
+        const data = await fetchProducts();
+        const all = data.product_categories.flatMap(c => c.products);
+        const product = all.find(p => p.product_id === id);
+        if (!product) {
+            DOM.productContainer.textContent = 'Продуктът не е намерен.';
+            return;
+        }
+        renderProduct(product);
+        renderRelated(all.filter(p => p.product_id !== id));
+    } catch (err) {
+        console.error(err);
+        DOM.productContainer.textContent = 'Грешка при зареждане на продукта.';
+    }
+}
+
+document.body.addEventListener('click', e => {
+    const btn = e.target.closest('.add-to-cart-btn');
+    if (btn) {
+        addToCart(btn.dataset.id, btn.dataset.name, btn.dataset.price, btn.dataset.inventory);
+    }
+});
+
+main();

--- a/product.html
+++ b/product.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="bg" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Продукт - BIOCODE</title>
+    <link rel="stylesheet" href="index.css">
+</head>
+<body>
+    <header class="main-header">
+        <div class="header-container">
+            <a href="index.html" class="logo-container" id="header-logo-link">
+                <img src="img/logo.svg" alt="BIOCODE Logo" id="header-logo-img">
+                <div><span class="brand-name">BIOCODE</span></div>
+            </a>
+            <nav class="main-nav">
+                <ul class="nav-links" id="main-nav-links">
+                    <li><a href="index.html">Начало</a></li>
+                    <li><a href="checkout.html" class="cart-link">Количка (<span id="cart-count">0</span>)</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main id="product-main" class="container" style="padding-top:var(--header-height);">
+        <div id="product-container"></div>
+        <section id="related-products-section">
+            <h2>Свързани продукти</h2>
+            <div class="product-grid" id="related-products-grid"></div>
+        </section>
+    </main>
+
+    <footer class="main-footer" style="padding:2rem 0;text-align:center;">
+        <a href="index.html" class="btn-primary">Назад към каталога</a>
+    </footer>
+
+    <script src="js/product.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `product.html` with basic layout for single product view
- implement `product.js` to load product details and show related items
- redirect clicks on catalog cards to the new product page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687da62e45d0832680183f5fd3b170eb