### PR TITLE
Add analytics tracking module

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -245,8 +245,10 @@
         </aside>
     </div>
 
-    <script>
+    <script type="module">
+import { trackPageView, trackPurchase } from "./js/analytics.js";
     document.addEventListener('DOMContentLoaded', () => {
+        trackPageView();
 
         // --- 1. Зареждане на количката от localStorage ---
         const cartData = JSON.parse(localStorage.getItem('cart') || '[]');
@@ -414,6 +416,7 @@
                 })
                 .then(() => {
                     localStorage.removeItem('cart');
+                    trackPurchase(fullOrder);
                     alert('Поръчката е приета успешно!');
                 })
                 .catch(err => {

--- a/config.js
+++ b/config.js
@@ -1,1 +1,5 @@
 export const API_URL = 'https://port.radilov-k.workers.dev';
+
+// Конфигурация за аналитичния инструмент
+export const ANALYTICS_URL = 'https://analytics.example.com/event';
+export const ANALYTICS_ID = 'YOUR_ANALYTICS_ID';

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,22 @@
+import { ANALYTICS_URL, ANALYTICS_ID } from '../config.js';
+
+function send(eventType, payload) {
+    if (!ANALYTICS_URL || !ANALYTICS_ID) return;
+    fetch(ANALYTICS_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: ANALYTICS_ID, type: eventType, payload })
+    }).catch(err => console.error('Analytics error:', err));
+}
+
+export function trackPageView(path = window.location.pathname) {
+    send('page_view', { path });
+}
+
+export function trackAddToCart(product) {
+    send('add_to_cart', product);
+}
+
+export function trackPurchase(order) {
+    send('purchase', order);
+}

--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,7 @@ import { addToCart, updateCartCount } from './cart.js';
 import { generateHeroHTML } from './components/hero.js';
 import { generateProductCategoryHTML } from './components/productCategory.js';
 import { generateInfoCardHTML } from './components/infoCard.js';
+import { trackPageView, trackAddToCart } from "./analytics.js";
 
 const DOM = {
     mainContainer: document.getElementById('main-content-container'),
@@ -128,6 +129,7 @@ function initializePageInteractions() {
                 addToCartBtn.dataset.price,
                 addToCartBtn.dataset.inventory
             );
+            trackAddToCart({ id: addToCartBtn.dataset.id, name: addToCartBtn.dataset.name, price: Number(addToCartBtn.dataset.price) });
             return;
         }
     });
@@ -355,6 +357,7 @@ async function main() {
 
         initializePageInteractions();
         initializeScrollSpy();
+        trackPageView();
 
     } catch (error) {
         console.error('Fatal Error: Could not load or render page content.', error);

--- a/js/product.js
+++ b/js/product.js
@@ -1,6 +1,7 @@
 import { fetchProducts } from './api.js';
 import { addToCart, updateCartCount } from './cart.js';
 import { generateProductCard } from './components/productCard.js';
+import { trackPageView, trackAddToCart } from "./analytics.js";
 
 const DOM = {
     productContainer: document.getElementById('product-container'),
@@ -44,6 +45,7 @@ async function main() {
         }
         renderProduct(product);
         renderRelated(all.filter(p => p.product_id !== id));
+        trackPageView();
     } catch (err) {
         console.error(err);
         DOM.productContainer.textContent = 'Грешка при зареждане на продукта.';
@@ -54,6 +56,7 @@ document.body.addEventListener('click', e => {
     const btn = e.target.closest('.add-to-cart-btn');
     if (btn) {
         addToCart(btn.dataset.id, btn.dataset.name, btn.dataset.price, btn.dataset.inventory);
+        trackAddToCart({ id: btn.dataset.id, name: btn.dataset.name, price: Number(btn.dataset.price) });
     }
 });
 


### PR DESCRIPTION
## Summary
- add a configurable analytics section in `config.js`
- implement new `analytics.js` module with basic tracking helpers
- call tracking helpers from main page and product page
- collect analytics events during checkout completion

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687da803b9088326b043cc60af4e69ca