### PR TITLE
Добавяне на трети fallback при fetch

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -13,6 +13,8 @@ async function fetchWithFallback(endpoint) {
     if (primary) return primary;
     const secondary = await tryFetch(endpoint.startsWith('/') ? endpoint : `/${endpoint}`);
     if (secondary) return secondary;
+    const tertiary = await tryFetch(endpoint.startsWith('/') ? endpoint.slice(1) : endpoint);
+    if (tertiary) return tertiary;
     throw new Error('Failed to fetch ' + endpoint);
 }
 


### PR DESCRIPTION
## Резюме
- добавен е трети опит за `fetch` без водеща `/`
- така `site_content.json` и `products.json` се търсят и в текущата директория

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687db10a03388326adc3763efee3f71e