### PR TITLE
Adopt light biotech theme across storefront

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="bg" data-theme="dark">
+<html lang="bg" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,10 +16,24 @@
     <link rel="stylesheet" href="index.css">
     <style>
         :root {
-            --bg-primary-dark: #0D0F12; --bg-secondary-dark: #12151A; --text-primary-dark: #E9ECEF; --text-secondary-dark: #A0AEC0; --accent-dark: #00E0E0; --border-color-dark: rgba(255, 255, 255, 0.1); --error-color-dark: #ff5c5c;
+            --bg-primary-light: #f3faf7; --bg-secondary-light: #ffffff; --text-primary-light: #0f2e33; --text-secondary-light: #4b6f76;
+            --accent-light: #1ec8a5; --accent-rgb-light: 30, 200, 165; --border-color-light: rgba(15, 46, 51, 0.12);
+            --success-color-light: #2ecf87; --error-color-light: #f26d6d; --text-on-accent-light: #043d32;
+            --bg-primary-dark: #0D0F12; --bg-secondary-dark: #12151A; --text-primary-dark: #E9ECEF; --text-secondary-dark: #A0AEC0;
+            --accent-dark: #00E0E0; --accent-rgb-dark: 0, 224, 224; --border-color-dark: rgba(255, 255, 255, 0.1); --error-color-dark: #ff5c5c; --text-on-accent-dark: #001f1f;
+            --bg-primary: var(--bg-primary-light); --bg-secondary: var(--bg-secondary-light); --text-primary: var(--text-primary-light);
+            --text-secondary: var(--text-secondary-light); --accent: var(--accent-light); --accent-rgb: var(--accent-rgb-light);
+            --border-color: var(--border-color-light); --error-color: var(--error-color-light); --text-on-accent: var(--text-on-accent-light);
+        }
+        [data-theme="light"] {
+            --bg-primary: var(--bg-primary-light); --bg-secondary: var(--bg-secondary-light); --text-primary: var(--text-primary-light);
+            --text-secondary: var(--text-secondary-light); --accent: var(--accent-light); --accent-rgb: var(--accent-rgb-light);
+            --border-color: var(--border-color-light); --error-color: var(--error-color-light); --text-on-accent: var(--text-on-accent-light);
         }
         [data-theme="dark"] {
-            --bg-primary: var(--bg-primary-dark); --bg-secondary: var(--bg-secondary-dark); --text-primary: var(--text-primary-dark); --text-secondary: var(--text-secondary-dark); --accent: var(--accent-dark); --border-color: var(--border-color-dark); --error-color: var(--error-color-dark);
+            --bg-primary: var(--bg-primary-dark); --bg-secondary: var(--bg-secondary-dark); --text-primary: var(--text-primary-dark);
+            --text-secondary: var(--text-secondary-dark); --accent: var(--accent-dark); --accent-rgb: var(--accent-rgb-dark);
+            --border-color: var(--border-color-dark); --error-color: var(--error-color-dark); --text-on-accent: var(--text-on-accent-dark);
         }
         * { margin: 0; padding: 0; box-sizing: border-box; }
         html { scroll-behavior: smooth; }
@@ -34,7 +48,7 @@
         .form-group { margin-bottom: 1rem; }
         .form-group label { display: block; font-size: 0.9rem; font-weight: 500; color: var(--text-secondary); margin-bottom: 0.5rem; }
         .form-group input { width: 100%; padding: 0.8rem; background-color: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 8px; color: var(--text-primary); font-size: 1rem; transition: border-color 0.3s, box-shadow 0.3s; }
-        .form-group input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px rgba(0, 224, 224, 0.2); }
+        .form-group input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.2); }
         .form-group input.is-invalid { border-color: var(--error-color); }
         .error-message { color: var(--error-color); font-size: 0.85rem; margin-top: 0.25rem; display: none; }
         input.is-invalid + .error-message { display: block; }
@@ -64,10 +78,9 @@
         .summary-row.total { font-size: 1.2rem; font-weight: bold; border-top: 1px solid var(--border-color); margin-top: 1rem; padding-top: 1rem; }
         .promo-code-form { display: flex; gap: 0.5rem; margin-top: 1rem; }
         .promo-code-form input { flex-grow: 1; }
-        .promo-code-form button { padding: 0.8rem; background-color: var(--accent); color: var(--bg-primary); border: none; border-radius: 8px; cursor: pointer; font-weight: 600; }
-        [data-theme="dark"] .promo-code-form button { color: #000; }
+        .promo-code-form button { padding: 0.8rem; background-color: var(--accent); color: var(--text-on-accent); border: none; border-radius: 8px; cursor: pointer; font-weight: 600; }
         /* Finalization */
-        .btn-submit { width: 100%; padding: 1rem; font-size: 1.1rem; font-weight: 700; color: #000; background-color: var(--accent); border: none; border-radius: 8px; cursor: pointer; transition: transform 0.2s, box-shadow 0.2s; }
+        .btn-submit { width: 100%; padding: 1rem; font-size: 1.1rem; font-weight: 700; color: var(--text-on-accent); background-color: var(--accent); border: none; border-radius: 8px; cursor: pointer; transition: transform 0.2s, box-shadow 0.2s; }
         .btn-submit:hover { transform: scale(1.02); box-shadow: 0 0 20px var(--accent); }
         .trust-seals { text-align: center; margin-top: 1.5rem; color: var(--text-secondary); font-size: 0.8rem; }
         @media (max-width: 992px) {

--- a/index.css
+++ b/index.css
@@ -3,6 +3,25 @@
 /* ======================================================= */
 
 :root {
+    /* Light Theme Variables */
+    --bg-primary-light: #f3faf7;
+    --bg-secondary-light: #ffffff;
+    --text-primary-light: #0f2e33;
+    --text-secondary-light: #4b6f76;
+    --accent-light: #1ec8a5;
+    --accent-rgb-light: 30, 200, 165;
+    --border-color-light: rgba(15, 46, 51, 0.12);
+    --shadow-light: rgba(15, 46, 51, 0.14);
+    --spotlight-color-light: rgba(30, 200, 165, 0.12);
+    --note-color-light: #168f76;
+    --success-color-light: #2ecf87;
+    --error-color-light: #f26d6d;
+    --text-on-accent-light: #043d32;
+    --skeleton-bg-light: #dff1eb;
+    --skeleton-highlight-light: #f6fdfa;
+    --header-bg-light: rgba(243, 250, 247, 0.9);
+    --overlay-bg-light: rgba(12, 62, 64, 0.35);
+
     /* Dark Theme Variables */
     --bg-primary-dark: #0D0F12;
     --bg-secondary-dark: #12151A;
@@ -15,14 +34,53 @@
     --spotlight-color-dark: rgba(0, 224, 224, 0.08);
     --note-color-dark: #ffd700;
     --success-color-dark: #20c997;
+    --error-color-dark: #ff5c5c;
+    --text-on-accent-dark: #001f1f;
     --skeleton-bg-dark: #1a1e25;
     --skeleton-highlight-dark: #2a303a;
-
     --header-bg-dark: rgba(13, 15, 18, 0.8);
-    --header-height: 70px;
     --overlay-bg-dark: rgba(0,0,0,0.5);
+
+    /* Applied Theme Variables */
+    --bg-primary: var(--bg-primary-light);
+    --bg-secondary: var(--bg-secondary-light);
+    --text-primary: var(--text-primary-light);
+    --text-secondary: var(--text-secondary-light);
+    --accent: var(--accent-light);
+    --accent-rgb: var(--accent-rgb-light);
+    --border-color: var(--border-color-light);
+    --shadow-color: var(--shadow-light);
+    --spotlight-color: var(--spotlight-color-light);
+    --note-color: var(--note-color-light);
+    --success-color: var(--success-color-light);
+    --error-color: var(--error-color-light);
+    --skeleton-bg: var(--skeleton-bg-light);
+    --skeleton-highlight: var(--skeleton-highlight-light);
+    --header-bg: var(--header-bg-light);
+    --overlay-bg: var(--overlay-bg-light);
+    --header-height: 70px;
+    --text-on-accent: var(--text-on-accent-light);
 }
 
+[data-theme="light"] {
+    --bg-primary: var(--bg-primary-light);
+    --bg-secondary: var(--bg-secondary-light);
+    --text-primary: var(--text-primary-light);
+    --text-secondary: var(--text-secondary-light);
+    --accent: var(--accent-light);
+    --accent-rgb: var(--accent-rgb-light);
+    --border-color: var(--border-color-light);
+    --shadow-color: var(--shadow-light);
+    --spotlight-color: var(--spotlight-color-light);
+    --note-color: var(--note-color-light);
+    --success-color: var(--success-color-light);
+    --error-color: var(--error-color-light);
+    --skeleton-bg: var(--skeleton-bg-light);
+    --skeleton-highlight: var(--skeleton-highlight-light);
+    --header-bg: var(--header-bg-light);
+    --overlay-bg: var(--overlay-bg-light);
+    --text-on-accent: var(--text-on-accent-light);
+}
 
 [data-theme="dark"] {
     --bg-primary: var(--bg-primary-dark);
@@ -36,10 +94,12 @@
     --spotlight-color: var(--spotlight-color-dark);
     --note-color: var(--note-color-dark);
     --success-color: var(--success-color-dark);
+    --error-color: var(--error-color-dark);
     --skeleton-bg: var(--skeleton-bg-dark);
     --skeleton-highlight: var(--skeleton-highlight-dark);
     --header-bg: var(--header-bg-dark);
     --overlay-bg: var(--overlay-bg-dark);
+    --text-on-accent: var(--text-on-accent-dark);
 }
 
 * {
@@ -165,6 +225,10 @@ main { padding-top: var(--header-height); }
     min-height: calc(100vh - var(--header-height));
     display: flex; flex-direction: column; justify-content: center; align-items: center;
     text-align: center; position: relative;
+    background:
+        radial-gradient(circle at 20% 20%, rgba(var(--accent-rgb), 0.18), transparent 58%),
+        radial-gradient(circle at 80% 0%, rgba(104, 198, 162, 0.2), transparent 60%),
+        linear-gradient(180deg, #f9fefc 0%, #eef7f4 45%, var(--bg-primary) 100%);
 }
 .hero-section .container { width: 100%; }
 #neuron-canvas {
@@ -182,7 +246,10 @@ main { padding-top: var(--header-height); }
 }
 
 /* --- INFO CARD SECTION --- */
-.info-card-section { padding: 4rem 0; }
+.info-card-section {
+    padding: 4rem 0;
+    background: linear-gradient(180deg, rgba(215, 238, 229, 0.28) 0%, rgba(243, 250, 247, 0.85) 100%);
+}
 .info-card-section .container { display: flex; align-items: center; gap: 3rem; }
 .info-card-section.image-align-right .container { flex-direction: row-reverse; }
 .info-card-image, .info-card-content { flex: 1; min-width: 300px; }
@@ -191,7 +258,7 @@ main { padding-top: var(--header-height); }
 .info-card-content p { color: var(--text-secondary); margin-bottom: 1.5rem; }
 .btn-primary {
     background-color: var(--accent);
-    color: var(--bg-primary);
+    color: var(--text-on-accent);
     padding: 0.8rem 1.5rem;
     border-radius: 8px;
     text-decoration: none;
@@ -199,7 +266,6 @@ main { padding-top: var(--header-height); }
     display: inline-block;
     transition: all 0.3s ease;
 }
-[data-theme="dark"] .btn-primary { color: #000; }
 .btn-primary:hover { transform: translateY(-3px) scale(1.05); box-shadow: 0 0 20px var(--accent); }
 
 
@@ -280,18 +346,16 @@ main { padding-top: var(--header-height); }
 .variant-item strong { font-size: 1rem; font-weight: 600; color: var(--text-primary); }
 .variant-item span { font-size: 0.85rem; color: var(--text-secondary); display: block; margin-top: 0.25rem; }
 .variant-link {
-    display: inline-block; text-decoration: none; color: var(--bg-primary); background: var(--accent);
+    display: inline-block; text-decoration: none; color: var(--text-on-accent); background: var(--accent);
     padding: 0.6rem 1rem; border-radius: 8px; font-weight: 600; transition: all 0.3s ease;
     margin-top: 0.75rem; font-size: 0.9rem;
 }
-[data-theme="dark"] .variant-link { color: #000; }
 .variant-link:hover { transform: scale(1.05); box-shadow: 0 0 15px var(--accent); }
 
 .add-to-cart-btn {
-    display: inline-block; background: var(--accent); color: var(--bg-primary); padding: 0.6rem 1rem; border: none;
+    display: inline-block; background: var(--accent); color: var(--text-on-accent); padding: 0.6rem 1rem; border: none;
     border-radius: 8px; font-weight: 600; cursor: pointer; transition: all 0.3s ease; margin-top: 1rem; font-size: 0.9rem;
 }
-[data-theme="dark"] .add-to-cart-btn { color: #000; }
 .add-to-cart-btn:hover { transform: scale(1.05); box-shadow: 0 0 15px var(--accent); }
 .add-to-cart-btn.added {
     background-color: var(--success-color);
@@ -318,14 +382,13 @@ main { padding-top: var(--header-height); }
 .effect-bar {
   width: 0; height: 100%; border-radius: 12px; background: transparent; box-shadow: none;
   display: flex; align-items: center; justify-content: flex-end; padding-right: 10px; box-sizing: border-box;
-  color: var(--bg-primary); font-weight: 600; font-size: 0.75rem;
+  color: var(--text-on-accent); font-weight: 600; font-size: 0.75rem;
   transition: width 1.5s cubic-bezier(0.25, 1, 0.5, 1), background 1.5s ease-out, box-shadow 1.5s ease-out;
 }
 .effect-bar.animated {
   background: linear-gradient(to right, rgba(var(--accent-rgb), 0.2), var(--accent));
   box-shadow: 0 0 12px rgba(var(--accent-rgb), 0.5);
 }
-[data-theme="dark"] .effect-bar { color: #000; }
         
 /* ======================================================= */
 /*          5. ФУТЪР                                     */

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="bg" data-theme="dark">
+<html lang="bg" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -20,7 +20,11 @@
     <script>
         (function() {
             try {
-                var theme = localStorage.getItem('theme') || 'dark';
+                var theme = localStorage.getItem('theme');
+                if (theme !== 'light') {
+                    theme = 'light';
+                    localStorage.setItem('theme', theme);
+                }
                 document.documentElement.setAttribute('data-theme', theme);
             } catch (e) {}
         })();

--- a/policy.html
+++ b/policy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="bg" data-theme="dark">
+<html lang="bg" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/quest.html
+++ b/quest.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="bg" data-theme="dark">
+<html lang="bg" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/questionnaire.css
+++ b/questionnaire.css
@@ -1,11 +1,42 @@
       :root {
+        --bg-primary-light: #f3faf7;
+        --bg-secondary-light: #ffffff;
+        --text-primary-light: #0f2e33;
+        --text-secondary-light: #4b6f76;
+        --accent-light: #1ec8a5;
+        --accent-rgb-light: 30, 200, 165;
+        --border-color-light: rgba(15, 46, 51, 0.12);
+        --error-color-light: #f26d6d;
+        --text-on-accent-light: #043d32;
         --bg-primary-dark: #0d0f12;
         --bg-secondary-dark: #12151a;
         --text-primary-dark: #e9ecef;
         --text-secondary-dark: #a0aec0;
         --accent-dark: #00e0e0;
+        --accent-rgb-dark: 0, 224, 224;
         --border-color-dark: rgba(255, 255, 255, 0.1);
         --error-color-dark: #e57373;
+        --text-on-accent-dark: #001f1f;
+        --bg-primary: var(--bg-primary-light);
+        --bg-secondary: var(--bg-secondary-light);
+        --text-primary: var(--text-primary-light);
+        --text-secondary: var(--text-secondary-light);
+        --accent: var(--accent-light);
+        --accent-rgb: var(--accent-rgb-light);
+        --border-color: var(--border-color-light);
+        --error-color: var(--error-color-light);
+        --text-on-accent: var(--text-on-accent-light);
+      }
+      [data-theme="light"] {
+        --bg-primary: var(--bg-primary-light);
+        --bg-secondary: var(--bg-secondary-light);
+        --text-primary: var(--text-primary-light);
+        --text-secondary: var(--text-secondary-light);
+        --accent: var(--accent-light);
+        --accent-rgb: var(--accent-rgb-light);
+        --border-color: var(--border-color-light);
+        --error-color: var(--error-color-light);
+        --text-on-accent: var(--text-on-accent-light);
       }
       [data-theme="dark"] {
         --bg-primary: var(--bg-primary-dark);
@@ -13,8 +44,10 @@
         --text-primary: var(--text-primary-dark);
         --text-secondary: var(--text-secondary-dark);
         --accent: var(--accent-dark);
+        --accent-rgb: var(--accent-rgb-dark);
         --border-color: var(--border-color-dark);
         --error-color: var(--error-color-dark);
+        --text-on-accent: var(--text-on-accent-dark);
       }
       * {
         margin: 0;
@@ -255,10 +288,7 @@
       }
       .nav-btn#next-btn {
         background-color: var(--accent);
-        color: var(--bg-primary);
-      }
-      [data-theme="dark"] .nav-btn#next-btn {
-        color: #000;
+        color: var(--text-on-accent);
       }
       .nav-btn#next-btn:hover {
         transform: translateY(-2px);

--- a/shipping.html
+++ b/shipping.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="bg" data-theme="dark">
+<html lang="bg" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/terms.html
+++ b/terms.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="bg" data-theme="dark">
+<html lang="bg" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- switch the storefront to a light, biotech-inspired color system with dedicated light/dark variables and accent legibility tweaks
- refresh hero and info card backgrounds to deliver a clean scientific aesthetic and ensure action buttons/readouts remain readable
- align auxiliary pages and questionnaire styles with the new palette and default the site to the light theme across visits

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc63c313d4832683cb6aecd36263d9